### PR TITLE
Added pkg-config (.pc) file for non-CMake consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,19 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GeoUtils
 )
 
+# pkg-config
+option(GEO_UTILS_INSTALL_PKGCONFIG "Install a pkg-config (.pc) file" ON)
+if(GEO_UTILS_INSTALL_PKGCONFIG)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/geo-utils.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/geo-utils.pc
+        @ONLY
+    )
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/geo-utils.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)
+endif()
+
 if(_geo_utils_is_top_level)                                                                                                                                                                                                                                                                                                                                               
     set(CPACK_PACKAGE_NAME    "geo-utils")
     set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")                                                                                                                                                                                                                                                                                                                       

--- a/cmake/geo-utils.pc.in
+++ b/cmake/geo-utils.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: geo-utils
+Description: Header-only C++ geographic utilities
+URL: https://github.com/gistrec/geo-utils
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
## Summary
  - Generate and install a `geo-utils.pc` file alongside the existing CMake package config, so non-CMake build systems (Make, Meson, autotools) and distro packagers can consume the library via `pkg-config --cflags geo-utils`.
  - Gated behind `GEO_UTILS_INSTALL_PKGCONFIG` (ON by default); installed to `${CMAKE_INSTALL_LIBDIR}/pkgconfig`.
  - Header-only — no `Libs:` field, only `Cflags: -I${includedir}`.