### PR TITLE
Added vcpkg installation docs and CI smoke test

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -58,18 +58,25 @@ jobs:
       # (the resolved includedir must actually contain our headers, not point at
       # a configure-time prefix that no longer matches the install location).
       # Skipped on Windows — pkg-config isn't part of the default toolchain.
+      #
+      # Expected version is derived from CMakeLists.txt rather than hardcoded
+      # so that a `project(... VERSION x.y.z ...)` bump doesn't silently leave
+      # this assertion testing the old number.
       - name: Verify pkg-config metadata
         if: runner.os != 'Windows'
         env:
           PKG_CONFIG_PATH: ${{ runner.temp }}/prefix/lib/pkgconfig
         run: |
+          expected_version=$(sed -nE 's/^project\(GeoUtilsCpp VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt)
+          test -n "$expected_version" || { echo "ERROR: could not parse project version from CMakeLists.txt" >&2; exit 1; }
           version=$(pkg-config --modversion geo-utils-cpp)
           cflags=$(pkg-config --cflags geo-utils-cpp)
           include_dir=$(pkg-config --variable=includedir geo-utils-cpp)
+          echo "expected:   $expected_version"
           echo "version:    $version"
           echo "cflags:     $cflags"
           echo "includedir: $include_dir"
-          test "$version" = "1.0.1"
+          test "$version" = "$expected_version"
           case "$cflags" in
             *//*) echo "ERROR: doubled-slash in include path: $cflags" >&2; exit 1 ;;
           esac

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -56,10 +56,15 @@ jobs:
       - uses: actions/checkout@v4
 
       # GH-hosted runners ship vcpkg pre-installed at $VCPKG_INSTALLATION_ROOT.
-      # The bundled checkout can lag the registry by days/weeks, so pull master
-      # to make sure the geo-utils-cpp port is present and current.
-      - name: Update vcpkg registry
-        run: git -C "$VCPKG_INSTALLATION_ROOT" pull --ff-only
+      # The bundled checkout can lag the registry by days/weeks, so sync to
+      # origin/master to make sure the geo-utils-cpp port is present and
+      # current. fetch+reset (rather than `pull --ff-only`) is robust against
+      # the runner image leaving HEAD detached or off master — the runner is
+      # disposable, so a hard reset is safe.
+      - name: Sync vcpkg registry
+        run: |
+          git -C "$VCPKG_INSTALLATION_ROOT" fetch --depth=1 origin master
+          git -C "$VCPKG_INSTALLATION_ROOT" reset --hard FETCH_HEAD
 
       - name: Install geo-utils-cpp via vcpkg
         run: "$VCPKG_INSTALLATION_ROOT/vcpkg" install geo-utils-cpp

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -1,0 +1,76 @@
+# vcpkg integration smoke test.
+#
+# Installs geo-utils-cpp from the official microsoft/vcpkg registry, then
+# configures and builds the minimal consumer project (tests/consumer/) using
+# the vcpkg CMake toolchain file. Runs on Linux/macOS/Windows in parallel.
+#
+# What this catches:
+#   - Breakage in the published vcpkg port
+#   - Drift in vcpkg infrastructure or GitHub runner images
+#   - Our exported CMake config / target name not surviving an install via vcpkg
+#
+# What this does NOT catch:
+#   - Regressions introduced in this repo on a PR — vcpkg ships the *released*
+#     version (currently 1.0.1), not HEAD. The PR/push runs verify the
+#     published port still works; the weekly schedule catches drift over time.
+#
+# Triggered automatically on push/PR to master/main; runs weekly to catch
+# upstream drift; can also be run manually from the Actions tab.
+
+name: vcpkg
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
+  schedule:
+    # Mondays 06:00 UTC. Catches drift in the vcpkg registry / runner images.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vcpkg-consumer:
+    name: vcpkg + consumer (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        # Bash is available on all GH-hosted runners (Git Bash on Windows) and
+        # gives us consistent $VCPKG_INSTALLATION_ROOT expansion across platforms.
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # GH-hosted runners ship vcpkg pre-installed at $VCPKG_INSTALLATION_ROOT.
+      # The bundled checkout can lag the registry by days/weeks, so pull master
+      # to make sure the geo-utils-cpp port is present and current.
+      - name: Update vcpkg registry
+        run: git -C "$VCPKG_INSTALLATION_ROOT" pull --ff-only
+
+      - name: Install geo-utils-cpp via vcpkg
+        run: "$VCPKG_INSTALLATION_ROOT/vcpkg" install geo-utils-cpp
+
+      - name: Configure consumer with vcpkg toolchain
+        run: |
+          cmake -S tests/consumer -B build-consumer \
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build consumer
+        run: cmake --build build-consumer --config Release
+
+      - name: Test consumer
+        run: ctest --test-dir build-consumer -C Release --output-on-failure

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ vcpkg install geo-utils-cpp
 Then in your `CMakeLists.txt`:
 
 ```cmake
-find_package(GeoUtilsCpp CONFIG REQUIRED)
+find_package(GeoUtilsCpp 1.0.1 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
     <a href="https://github.com/gistrec/geo-utils-cpp/actions/workflows/ci.yml">
         <img src="https://github.com/gistrec/geo-utils-cpp/actions/workflows/ci.yml/badge.svg" alt="CI">
     </a>
+    <a href="https://github.com/gistrec/geo-utils-cpp/actions/workflows/vcpkg.yml">
+        <img src="https://github.com/gistrec/geo-utils-cpp/actions/workflows/vcpkg.yml/badge.svg" alt="vcpkg">
+    </a>
     <a href="https://app.codacy.com/gh/gistrec/geo-utils-cpp/dashboard">
       <img src="https://img.shields.io/codacy/grade/bcff544711544d5fb7da95b68abf566d" alt="Code quality">
     </a>
@@ -70,6 +73,19 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(GeoUtilsCpp)
 
+target_link_libraries(your_target PRIVATE geo::utils)
+```
+
+### vcpkg
+
+```sh
+vcpkg install geo-utils-cpp
+```
+
+Then in your `CMakeLists.txt`:
+
+```cmake
+find_package(GeoUtilsCpp CONFIG REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,33 @@ FetchContent_MakeAvailable(GeoUtilsCpp)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 
+### vcpkg
+
+The library is available in the official [vcpkg registry](https://github.com/microsoft/vcpkg).
+
+Classic mode:
+
+```sh
+vcpkg install geo-utils-cpp
+```
+
+Manifest mode — add to your `vcpkg.json`:
+
+```json
+{
+  "dependencies": [
+    "geo-utils-cpp"
+  ]
+}
+```
+
+Then consume it from CMake:
+
+```cmake
+find_package(GeoUtilsCpp CONFIG REQUIRED)
+target_link_libraries(your_target PRIVATE geo::utils)
+```
+
 ### find_package
 
 Install the library first, then:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ Manifest mode — add to your `vcpkg.json`:
 Then consume it from CMake:
 
 ```cmake
-find_package(GeoUtilsCpp CONFIG REQUIRED)
+find_package(GeoUtilsCpp 1.0.1 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 

--- a/tests/consumer/CMakeLists.txt
+++ b/tests/consumer/CMakeLists.txt
@@ -5,7 +5,10 @@ project(geo_utils_cpp_consumer LANGUAGES CXX)
 # link against geo::utils, and run a minimal program. Intended to be configured
 # against an install prefix from the install workflow.
 
-find_package(GeoUtilsCpp 1.0.1 REQUIRED)
+# No version pinned: this is a smoke test for findability/linkage, not a
+# version-compatibility check. Version assertions live in install.yml's
+# pkg-config step (which derives the expected version from CMakeLists.txt).
+find_package(GeoUtilsCpp REQUIRED)
 
 add_executable(app main.cpp)
 target_link_libraries(app PRIVATE geo::utils)


### PR DESCRIPTION
## Summary

geo-utils-cpp is now in the official vcpkg registry (microsoft/vcpkg#51592).

This PR documents the new install path and adds CI to verify it stays healthy:
- README + `docs/getting-started.md`: added a `vcpkg` section (classic + manifest mode).
- New workflow `.github/workflows/vcpkg.yml`: installs the published port and builds `tests/consumer/` against it on Linux/macOS/Windows.
- Runs on push/PR plus a weekly schedule to catch drift in the vcpkg registry and runner images between our releases.

## Test plan
- [ ] vcpkg workflow is green on all three OS
- [ ] vcpkg badge renders in README