### PR TITLE
Fix invalid YAML in vcpkg workflow

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -67,7 +67,8 @@ jobs:
           git -C "$VCPKG_INSTALLATION_ROOT" reset --hard FETCH_HEAD
 
       - name: Install geo-utils-cpp via vcpkg
-        run: "$VCPKG_INSTALLATION_ROOT/vcpkg" install geo-utils-cpp
+        run: |
+          "$VCPKG_INSTALLATION_ROOT/vcpkg" install geo-utils-cpp
 
       - name: Configure consumer with vcpkg toolchain
         run: |


### PR DESCRIPTION
## Summary

The vcpkg workflow added in #12 fails to load with:

```text
Invalid workflow file: .github/workflows/vcpkg.yml#L68
```

The root cause is on line 70:

```yaml
run: "$VCPKG_INSTALLATION_ROOT/vcpkg" install geo-utils-cpp
```

After the closing quote, YAML does not accept the trailing tokens.

Switched the step to a literal block scalar (`run: |`), matching the style of the surrounding steps.

## Test plan

- [ ] vcpkg workflow loads and runs on push
