### PR TITLE
Add xrepo install docs and weekly smoke test

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -9,21 +9,16 @@
 #   - Drift in vcpkg infrastructure or GitHub runner images
 #   - Our exported CMake config / target name not surviving an install via vcpkg
 #
-# What this does NOT catch:
-#   - Regressions introduced in this repo on a PR — vcpkg ships the *released*
-#     version (currently 1.0.1), not HEAD. The PR/push runs verify the
-#     published port still works; the weekly schedule catches drift over time.
-#
-# Triggered automatically on push/PR to master/main; runs weekly to catch
-# upstream drift; can also be run manually from the Actions tab.
+# Triggers: weekly cron + manual dispatch only. This workflow tests the
+# *released* version (currently 1.0.1) from the vcpkg registry, not HEAD,
+# so running it on every PR/push would produce a misleading green check
+# (it cannot fail on a PR that breaks HEAD). Cron catches registry / runner
+# drift over time; use workflow_dispatch when bumping the port version.
+# If the workflow itself or tests/consumer/ changes, run it manually.
 
 name: vcpkg
 
 on:
-  push:
-    branches: [master, main]
-  pull_request:
-    branches: [master, main]
   workflow_dispatch:
   schedule:
     # Mondays 06:00 UTC. Catches drift in the vcpkg registry / runner images.

--- a/.github/workflows/xrepo.yml
+++ b/.github/workflows/xrepo.yml
@@ -1,0 +1,71 @@
+# xrepo integration smoke test.
+#
+# Installs geo-utils-cpp from the official xmake-io/xmake-repo registry, then
+# builds and runs the minimal consumer project (tests/consumer/main.cpp) via
+# its xmake.lua. Runs on Linux/macOS/Windows in parallel.
+#
+# What this catches:
+#   - Breakage in the published xrepo package recipe
+#   - Drift in xmake-repo or GitHub runner images
+#   - Our public header layout not surviving an install via xrepo
+#
+# Triggers: weekly cron + manual dispatch only. This workflow tests the
+# *released* version (currently 1.0.1) from xmake-repo, not HEAD, so running
+# it on every PR/push would produce a misleading green check (it cannot fail
+# on a PR that breaks HEAD). Cron catches registry / runner drift over time;
+# use workflow_dispatch when bumping the package version. If the workflow
+# itself or tests/consumer/ changes, run it manually.
+
+name: xrepo
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Tuesdays 06:00 UTC. Offset from vcpkg.yml to spread runner load.
+    - cron: '0 6 * * 2'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  xrepo-consumer:
+    name: xrepo + consumer (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup xmake
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: latest
+
+      # xmake caches the package registry locally; refresh so the just-published
+      # port is visible. Matches the `vcpkg` workflow's "Sync vcpkg registry" step.
+      - name: Update xmake-repo
+        run: xmake repo --update -v
+
+      # `xmake config` resolves `add_requires("geo-utils-cpp")` against xmake-repo
+      # and installs it into the local xmake cache.
+      - name: Build consumer via xrepo
+        working-directory: tests/consumer
+        run: |
+          xmake config --yes --mode=release
+          xmake build smoke
+
+      - name: Run consumer smoke test
+        working-directory: tests/consumer
+        run: xmake run smoke

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
     <a href="https://github.com/gistrec/geo-utils-cpp/actions/workflows/vcpkg.yml">
         <img src="https://github.com/gistrec/geo-utils-cpp/actions/workflows/vcpkg.yml/badge.svg" alt="vcpkg">
     </a>
+    <a href="https://github.com/gistrec/geo-utils-cpp/actions/workflows/xrepo.yml">
+        <img src="https://github.com/gistrec/geo-utils-cpp/actions/workflows/xrepo.yml/badge.svg" alt="xrepo">
+    </a>
     <a href="https://app.codacy.com/gh/gistrec/geo-utils-cpp/dashboard">
       <img src="https://img.shields.io/codacy/grade/bcff544711544d5fb7da95b68abf566d" alt="Code quality">
     </a>
@@ -87,6 +90,21 @@ Then in your `CMakeLists.txt`:
 ```cmake
 find_package(GeoUtilsCpp 1.0.1 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
+```
+
+### xrepo
+
+```sh
+xrepo install geo-utils-cpp
+```
+
+Or declare it as a dependency in your `xmake.lua`:
+
+```lua
+add_requires("geo-utils-cpp")
+
+target("your_target")
+    add_packages("geo-utils-cpp")
 ```
 
 ### find_package

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,6 +49,33 @@ find_package(GeoUtilsCpp 1.0.1 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 
+### xrepo
+
+The library is available in the official
+[xmake-repo](https://github.com/xmake-io/xmake-repo) registry as
+`geo-utils-cpp`.
+
+Install via the `xrepo` CLI:
+
+```sh
+xrepo install geo-utils-cpp
+```
+
+Or declare it as a dependency in your `xmake.lua`:
+
+```lua
+add_requires("geo-utils-cpp")
+
+target("your_target")
+    set_kind("binary")
+    add_files("main.cpp")
+    add_packages("geo-utils-cpp")
+```
+
+A minimal smoke-test consumer (`tests/consumer/`) is included for both CMake
+and xmake builds — see [`tests/consumer/xmake.lua`](../tests/consumer/xmake.lua)
+for the xmake variant.
+
 ### find_package
 
 Install the library first, then:

--- a/tests/consumer/xmake.lua
+++ b/tests/consumer/xmake.lua
@@ -1,0 +1,12 @@
+-- Smoke test for an installed geo-utils-cpp package via xrepo.
+-- Mirrors CMakeLists.txt: declare the dependency, link, build, run main.cpp.
+-- Used by .github/workflows/xrepo.yml.
+
+set_languages("c++17")
+
+add_requires("geo-utils-cpp")
+
+target("smoke")
+    set_kind("binary")
+    add_files("main.cpp")
+    add_packages("geo-utils-cpp")


### PR DESCRIPTION
## Summary

- `geo-utils-cpp` was just merged to [xmake-io/xmake-repo](https://github.com/xmake-io/xmake-repo/tree/master/packages/g/geo-utils-cpp) (xmake-io/xmake-repo#9942). Adds an **xrepo** install section to README and `docs/getting-started.md`, plus a CI badge.
- Adds `.github/workflows/xrepo.yml`: weekly smoke test that installs the published package on Linux/macOS/Windows and builds `tests/consumer/main.cpp` via xrepo. Mirrors `vcpkg.yml`.
- Adds `tests/consumer/xmake.lua` so the same consumer `main.cpp` is exercised by both CMake (existing) and xmake (new) — no duplication.
- Tightens triggers on `vcpkg.yml` (and applies same to `xrepo.yml`): both install the **released** package, not HEAD, so push/PR runs produced a misleading green check on PRs that broke HEAD. Reduced to `workflow_dispatch` + weekly cron, which is the only signal that actually catches registry / runner drift.

Closes gistrec/geo-utils-cpp#19.

## Test plan

- [ ] Trigger `xrepo` workflow manually via Actions tab → all three OS jobs pass
- [ ] Confirm `vcpkg` badge still renders (no behavior change beyond trigger frequency)
- [ ] Spot-check rendered README on GitHub for new badge and new install section