### PR TITLE
Release 1.0.2; rename build2 package to libgeo-utils-cpp

### DIFF
--- a/.github/workflows/build2.yml
+++ b/.github/workflows/build2.yml
@@ -1,11 +1,11 @@
 # build2 packaging smoke test.
 #
 # Validates the build2 metadata (manifest + buildfiles) against the real build2
-# toolchain: configures, "builds" the binless (header-only) lib{geo-utils},
+# toolchain: configures, "builds" the binless (header-only) lib{geo-utils-cpp},
 # installs to a temporary prefix, asserts the headers land under
 # <prefix>/include/geo/ with the detail/ subdirectory preserved, and finally
 # compiles + runs a consumer (tests/consumer/main.cpp) against the installed
-# package via the generated libgeo-utils.pc — so a broken export interface
+# package via the generated libgeo-utils-cpp.pc — so a broken export interface
 # (cxx.export.poptions / .pc) fails here too, not just a missing file.
 #
 # This is the build2 analogue of the CMake-based install.yml: it catches
@@ -97,7 +97,7 @@ jobs:
           find "$inst/include/geo" -type f | sort
 
       # Compile + run a real consumer against the *installed* package, resolving
-      # the include path through the generated libgeo-utils.pc. This exercises
+      # the include path through the generated libgeo-utils-cpp.pc. This exercises
       # the export interface end-to-end (cxx.export.poptions -> .pc -> -I), which
       # the file-existence check above cannot. pkg-config ships on the macOS
       # runner image; install pkgconf as a fallback just in case.
@@ -107,9 +107,9 @@ jobs:
           command -v pkg-config >/dev/null || brew install pkgconf
           inst="$RUNNER_TEMP/inst"
           export PKG_CONFIG_PATH="$inst/lib/pkgconfig"
-          pkg-config --exists libgeo-utils
-          cflags=$(pkg-config --cflags libgeo-utils)
-          echo "pkg-config --cflags libgeo-utils: $cflags"
+          pkg-config --exists libgeo-utils-cpp
+          cflags=$(pkg-config --cflags libgeo-utils-cpp)
+          echo "pkg-config --cflags libgeo-utils-cpp: $cflags"
           c++ -std=c++17 $cflags tests/consumer/main.cpp -o "$RUNNER_TEMP/consumer"
           "$RUNNER_TEMP/consumer"
           echo "build2 consumer compile + run OK"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/*
 !build/root.build
 build-*/
 
+# build2 dependency tool (bdep) per-developer project state, created by `bdep init`.
+.bdep/
+
 # Compiled Object files
 *.slo
 *.lo

--- a/README.md
+++ b/README.md
@@ -109,22 +109,22 @@ Conan Center support is pending
 
 ### build2 / bpkg
 
-> **Package name note:** in the build2 ecosystem this library follows the
-> build2 `libfoo` convention and is named **`libgeo-utils`** (cppget.org
-> submission pending). Everywhere else — GitHub project, CMake, vcpkg, Conan,
-> xrepo — it is named **`geo-utils-cpp`**. Both names refer to the same library,
-> same headers, same `#include <geo/...>` API.
+> **Package name note:** in the build2 ecosystem this library carries the
+> conventional `lib` prefix and is named **`libgeo-utils-cpp`** (cppget.org
+> submission pending) — i.e. the same `geo-utils-cpp` with `lib` in front.
+> Everywhere else (GitHub, CMake, vcpkg, Conan, xrepo) it stays
+> **`geo-utils-cpp`**. Same library, same headers, same `#include <geo/...>` API.
 
 Add the dependency to your package's `manifest`:
 
 ```
-depends: libgeo-utils ^1.0.1
+depends: libgeo-utils-cpp ^1.0.1
 ```
 
 And in the consuming `buildfile`:
 
 ```
-import libs = libgeo-utils%lib{geo-utils}
+import libs = libgeo-utils-cpp%lib{geo-utils-cpp}
 
 exe{hello}: cxx{hello} $libs
 ```

--- a/build/bootstrap.build
+++ b/build/bootstrap.build
@@ -1,4 +1,4 @@
-project = libgeo-utils
+project = libgeo-utils-cpp
 
 using version
 

--- a/include/geo/buildfile
+++ b/include/geo/buildfile
@@ -1,7 +1,7 @@
-lib{geo-utils}: hxx{**}
+lib{geo-utils-cpp}: hxx{**}
 
 # Public include path: consumers do `#include <geo/...>`.
-lib{geo-utils}: cxx.export.poptions = "-I$out_root/include" "-I$src_root/include"
+lib{geo-utils-cpp}: cxx.export.poptions = "-I$out_root/include" "-I$src_root/include"
 
 # Install headers under <prefix>/include/geo/, preserving the detail/ subdir.
 hxx{*}:

--- a/manifest
+++ b/manifest
@@ -1,5 +1,5 @@
 : 1
-name: libgeo-utils
+name: libgeo-utils-cpp
 version: 1.0.1
 project: geo-utils-cpp
 language: c++
@@ -11,4 +11,7 @@ description-type: text/markdown
 changes-file: CHANGELOG.md
 changes-type: text/markdown
 url: https://github.com/gistrec/geo-utils-cpp
+doc-url: https://github.com/gistrec/geo-utils-cpp/tree/master/docs
+src-url: https://github.com/gistrec/geo-utils-cpp
 email: gistrec@gmail.com
+build-error-email: gistrec@gmail.com


### PR DESCRIPTION
## Summary

Prepares the 1.0.2 release and finalizes the build2 package name.

- **Bump version 1.0.1 → 1.0.2** across `manifest`, the CMake project, and the
  README install snippets (FetchContent tag, Conan, build2 `depends`,
  `find_package`).
- **Rename the build2 package** `libgeo-utils` → **`libgeo-utils-cpp`** (manifest
  `name`, `build/bootstrap.build` project, the `lib{geo-utils-cpp}` target, and
  the generated `libgeo-utils-cpp.pc`) so Repology can group the cppget package
  with the `geo-utils-cpp` it already tracks via Vcpkg. The `geo-utils-cpp` name
  is unchanged everywhere else and the `#include <geo/...>` API is untouched.
- **Polish `manifest`**: add `doc-url`, `src-url`, `build-error-email`.
- **`.gitignore`**: ignore bdep's per-developer `.bdep/` directory.
- **CHANGELOG**: write the v1.0.2 entry covering the whole release since 1.0.1 —
  vcpkg/xrepo/build2 packaging, the math hot-path and `heading()` optimizations,
  and the benchmark suite.

## Test plan

- [x] `build2` CI (macOS): `b install` to a temp prefix; headers land at
  `<prefix>/include/geo/*.hpp` incl. `detail/math.hpp`; consumer compiles + runs
  via `pkg-config --cflags libgeo-utils-cpp`.
- [x] `b info` reports `project: libgeo-utils-cpp`, `version: 1.0.2`.
- [x] CMake / vcpkg / xrepo CI unaffected.

> Still not published on cppget.org — that needs a `v1.0.2` tag + `bdep publish`
> as a follow-up.