### PR TITLE
Release 1.0.2

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,7 +2,7 @@
 #
 # Installs the library to a temporary prefix, then configures and builds a
 # minimal consumer project (tests/consumer/) against that prefix using
-# `find_package(GeoUtilsCpp 1.0.1 REQUIRED)` and `target_link_libraries(... geo::utils)`.
+# `find_package(GeoUtilsCpp REQUIRED)` and `target_link_libraries(... geo::utils)`.
 # Runs the consumer to verify end-to-end integration.
 #
 # Catches regressions in install paths, exported target names, and

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -10,7 +10,7 @@
 #   - Our exported CMake config / target name not surviving an install via vcpkg
 #
 # Triggers: weekly cron + manual dispatch only. This workflow tests the
-# *released* version (currently 1.0.1) from the vcpkg registry, not HEAD,
+# *released* version from the vcpkg registry, not HEAD,
 # so running it on every PR/push would produce a misleading green check
 # (it cannot fail on a PR that breaks HEAD). Cron catches registry / runner
 # drift over time; use workflow_dispatch when bumping the port version.

--- a/.github/workflows/xrepo.yml
+++ b/.github/workflows/xrepo.yml
@@ -10,7 +10,7 @@
 #   - Our public header layout not surviving an install via xrepo
 #
 # Triggers: weekly cron + manual dispatch only. This workflow tests the
-# *released* version (currently 1.0.1) from xmake-repo, not HEAD, so running
+# *released* version from xmake-repo, not HEAD, so running
 # it on every PR/push would produce a misleading green check (it cannot fail
 # on a PR that breaks HEAD). Cron catches registry / runner drift over time;
 # use workflow_dispatch when bumping the package version. If the workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## v1.0.2
+
+Performance optimizations to the spherical math hot path, new benchmarks, and
+expanded packaging: the library can now be consumed via vcpkg, xrepo, and
+build2 in addition to CMake / FetchContent. The public C++ API is unchanged.
+
+### Added
+
+- vcpkg packaging: installable as `geo-utils-cpp` from the vcpkg registry.
+- xrepo packaging: installable as `geo-utils-cpp` (xmake).
+- build2 / bpkg packaging (`manifest`, buildfiles) exposing a binless
+  `lib{geo-utils-cpp}` target. In the build2 ecosystem the package carries the
+  conventional `lib` prefix and is named `libgeo-utils-cpp`; everywhere else
+  (GitHub, CMake, vcpkg, Conan, xrepo) it stays `geo-utils-cpp`.
+- Benchmarks (`docs/benchmarks.md`, `benchmarks/`) comparing speed and binary
+  size against S2 Geometry, Boost.Geometry, GeographicLib, and a naive
+  haversine baseline.
+- CI smoke tests for the vcpkg, xrepo, build2, and benchmark builds.
+
+### Performance
+
+- Math hot path: precompute `kDegToRad` / `kRadToDeg` so `deg2rad` / `rad2deg`
+  use a single multiply, and make the `arc_hav` clamp branch-free.
+- `heading()`: cache the per-call latitude `sin` / `cos` values and fold the two
+  `deg2rad` conversions into one. Results are unchanged.
+
+### Docs
+
+- Expanded `docs/getting-started.md` and `docs/api.md`.
+
+### Unchanged (downstream-compatible)
+
+- Public C++ API, the `geo::` and `geo::detail::` namespaces, the public
+  headers, and the CMake `geo::utils` target — no source changes needed
+  downstream.
+
 ## v1.0.1
 
 Renamed package to `geo-utils-cpp` to avoid a name collision with an existing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(GeoUtilsCpp VERSION 1.0.1 LANGUAGES CXX)
+project(GeoUtilsCpp VERSION 1.0.2 LANGUAGES CXX)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(_geo_utils_cpp_is_top_level ON)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ include(FetchContent)
 FetchContent_Declare(
     GeoUtilsCpp
     GIT_REPOSITORY https://github.com/gistrec/geo-utils-cpp.git
-    GIT_TAG        v1.0.1
+    GIT_TAG        v1.0.2
 )
 FetchContent_MakeAvailable(GeoUtilsCpp)
 
@@ -101,7 +101,7 @@ target("your_target")
 ### Conan
 
 ```sh
-conan install --requires=geo-utils-cpp/1.0.1 --build=missing
+conan install --requires=geo-utils-cpp/1.0.2 --build=missing
 ```
 
 Conan Center support is pending
@@ -118,7 +118,7 @@ Conan Center support is pending
 Add the dependency to your package's `manifest`:
 
 ```
-depends: libgeo-utils-cpp ^1.0.1
+depends: libgeo-utils-cpp ^1.0.2
 ```
 
 And in the consuming `buildfile`:
@@ -147,7 +147,7 @@ With any of the above methods (vcpkg, xrepo, Conan, FetchContent, or a
 system `find_package`), wire it into your build with:
 
 ```cmake
-find_package(GeoUtilsCpp 1.0.1 REQUIRED)
+find_package(GeoUtilsCpp 1.0.2 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ include(FetchContent)
 FetchContent_Declare(
     GeoUtilsCpp
     GIT_REPOSITORY https://github.com/gistrec/geo-utils-cpp.git
-    GIT_TAG        v1.0.1
+    GIT_TAG        v1.0.2
 )
 FetchContent_MakeAvailable(GeoUtilsCpp)
 
@@ -64,7 +64,7 @@ for new projects, since the manifest commits alongside your source):
 Either mode, then consume it from CMake:
 
 ```cmake
-find_package(GeoUtilsCpp 1.0.1 REQUIRED)
+find_package(GeoUtilsCpp 1.0.2 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 
@@ -98,7 +98,7 @@ for the xmake variant.
 ### Conan
 
 ```sh
-conan install --requires=geo-utils-cpp/1.0.1 --build=missing
+conan install --requires=geo-utils-cpp/1.0.2 --build=missing
 ```
 
 Conan Center support is pending
@@ -118,7 +118,7 @@ cmake --install build-cmake --prefix /usr/local
 ```
 
 ```cmake
-find_package(GeoUtilsCpp 1.0.1 REQUIRED)
+find_package(GeoUtilsCpp 1.0.2 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 

--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libgeo-utils-cpp
-version: 1.0.1
+version: 1.0.2
 project: geo-utils-cpp
 language: c++
 summary: Header-only C++17 geographic geometry utilities


### PR DESCRIPTION
## Summary

Cuts the 1.0.2 release. master already carries the work accumulated since 1.0.1
— vcpkg/xrepo/build2 packaging, the math hot-path and `heading()` spherical
optimizations, and the benchmark suite — plus the `libgeo-utils-cpp` build2
rename from #22. This PR just sets the version and writes the changelog.

- Bump 1.0.1 → 1.0.2 in `manifest`, the CMake project, and the README install
  snippets (FetchContent tag, Conan, build2 `depends`, `find_package`).
- Add the v1.0.2 `CHANGELOG.md` entry covering the whole release: vcpkg / xrepo /
  build2 packaging, the spherical math optimizations, and the benchmarks.

## Test plan

- [x] `b info` reports `project: libgeo-utils-cpp`, `version: 1.0.2`.
- [x] Version/docs only — no functional source change.

After merge: tag `v1.0.2` + GitHub release, then optionally `bdep publish` to
cppget.org.