### PR TITLE
Document distance_to_segment limits; fix epsilon doc and test helper

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -50,7 +50,7 @@ geo::LatLng otherPoint = northPole;
 ### Equality
 
 `operator==` performs an **approximate** comparison with tolerance
-`LatLng::kDefaultEpsilon` (= `1e-12` degrees, ≈ 0.1 nanometers on Earth).
+`LatLng::kDefaultEpsilon` (= `1e-12` degrees, ≈ 0.1 micrometers on Earth).
 Longitudes are compared modulo 360°, so `LatLng(0, 180) == LatLng(0, -180)`.
 
 For custom tolerance — e.g. comparing computation results at meter scale —
@@ -354,9 +354,19 @@ std::cout << geo::on_path(geo::LatLng{5, 0}, polyline); // false — closing edg
 
 ### distance_to_segment
 
-**`geo::distance_to_segment(const LatLng& point, const LatLng& start, const LatLng& end)`** — Returns the distance in meters from `point` to the closest point on the line segment `[start, end]` on the sphere. If the perpendicular foot falls outside the segment, returns the distance to the nearer endpoint.
+**`geo::distance_to_segment(const LatLng& point, const LatLng& start, const LatLng& end)`** — Returns the distance in meters from `point` to the closest point on the line segment `[start, end]`. If the perpendicular foot falls outside the segment, returns the distance to the nearer endpoint.
 
 Returns: `double` — distance in meters, always ≥ 0.
+
+> **Approximation.** The closest point is found by planar projection in raw
+> `(lat, lng)` coordinate space (same algorithm as android-maps-utils
+> `PolyUtil.distanceToLine`), and the great-circle distance to that point is
+> returned. Accurate for short segments away from the poles. Two limitations:
+> longitude is not scaled by `cos(lat)`, so the result can overshoot by a few
+> percent at high latitudes (around `lat 80°`); and longitudes are used as-is,
+> so segments crossing the antimeridian (`±180°`) yield meaningless results —
+> a point lying exactly on such a segment can report kilometers of distance.
+> For tolerance checks against true geodesic segments, use `on_path`.
 
 ```cpp
 geo::LatLng start{28.05359, -82.41632};

--- a/include/geo/detail/math.hpp
+++ b/include/geo/detail/math.hpp
@@ -75,7 +75,10 @@ inline constexpr double kRadToDeg = 180.0 / kPi;
 
 // Returns hav(asin(x)).
 [[nodiscard]] inline double hav_from_sin(double x) noexcept {
-    double x2 = x * x;
+    // Clamp: |x| can exceed 1 by FP noise (e.g. the sin_delta_bearing
+    // quotient); sqrt(1 - x2) would return NaN and silently break
+    // is_on_segment_gc.
+    double x2 = std::min(x * x, 1.0);
     return x2 / (1.0 + std::sqrt(1.0 - x2)) * 0.5;
 }
 

--- a/include/geo/latlng.hpp
+++ b/include/geo/latlng.hpp
@@ -19,9 +19,9 @@
 namespace geo {
 
 struct LatLng {
-    // Default tolerance used by operator==. Roughly 0.1 nanometers on Earth —
-    // tighter than any practical computation, but loose enough for round-trips
-    // through deg2rad/rad2deg and similar identities.
+    // Default tolerance used by operator==. Roughly 0.1 micrometers (111 nm)
+    // on Earth — tighter than any practical computation, but loose enough for
+    // round-trips through deg2rad/rad2deg and similar identities.
     static constexpr double kDefaultEpsilon = 1e-12;
 
     double lat;

--- a/include/geo/poly.hpp
+++ b/include/geo/poly.hpp
@@ -237,8 +237,18 @@ template <typename Path>
 }
 
 /**
- * Computes the spherical distance between the point p and the line segment
+ * Computes the distance between the point p and the line segment
  * (start, end), in meters.
+ *
+ * Approximation: the closest point is found by planar projection in raw
+ * (lat, lng) coordinate space, then the great-circle distance to it is
+ * returned. Accurate for short segments away from the poles. Limitations:
+ * - longitude is not scaled by cos(lat), so the projection skews at high
+ *   latitudes and the result can overshoot by a few percent around lat 80°;
+ * - longitudes are used as-is: a segment crossing the antimeridian (±180°)
+ *   is treated as spanning nearly the whole globe and yields meaningless
+ *   results (a point on such a segment can report a distance of kilometers).
+ * For tolerance checks against true geodesic segments use on_path instead.
  */
 [[nodiscard]] inline double distance_to_segment(const LatLng& p, const LatLng& start, const LatLng& end) noexcept {
     if (start == end) {

--- a/tests/math/mod.hpp
+++ b/tests/math/mod.hpp
@@ -76,6 +76,15 @@ TEST(Math, hav_from_sin) {
     EXPECT_NEAR(sin_from_hav(hav_from_sin(0.7)), 0.7, 1e-10);
 }
 
+TEST(Math, hav_from_sin_clamp) {
+    // Floating-point rounding can push |x| slightly above 1 (e.g. the
+    // sin_delta_bearing quotient in poly.hpp). hav_from_sin must clamp rather
+    // than feed a negative value to sqrt and return NaN — a NaN cross-track
+    // silently turns is_on_segment_gc into a false positive.
+    EXPECT_NEAR(hav_from_sin(std::nextafter( 1.0,  2.0)), 0.5, 1e-10); // x > 1  → hav(π/2)
+    EXPECT_NEAR(hav_from_sin(std::nextafter(-1.0, -2.0)), 0.5, 1e-10); // x < -1 → hav(π/2)
+}
+
 TEST(Math, sin_sum_from_hav) {
     // sin(0 + 0) == 0
     EXPECT_NEAR(sin_sum_from_hav(0.0, 0.0), 0.0, 1e-10);

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -3,15 +3,17 @@
 #include <gtest/gtest.h>
 #include <geo/detail/math.hpp>
 
-// Checks that two LatLng values agree within 1e-6. Longitude is weighted by
-// cos(lat) so the assertion degenerates gracefully at poles where longitude is
-// geometrically undefined. Both longitudes are wrapped to (-180, 180] first so
-// that -180 and +180 (the same antimeridian point) compare as equal.
-#define EXPECT_NEAR_LatLng(expected, actual)                                          \
-    do {                                                                              \
-        EXPECT_NEAR((expected).lat, (actual).lat, 1e-6);                              \
-        const double _cosLat = std::cos(::geo::detail::deg2rad((expected).lat));      \
-        const double _eLng = ::geo::detail::wrap((expected).lng, -180.0, 180.0);      \
-        const double _aLng = ::geo::detail::wrap((actual).lng,   -180.0, 180.0);      \
-        EXPECT_NEAR(_cosLat * _eLng, _cosLat * _aLng, 1e-6);                          \
+// Checks that two LatLng values agree within 1e-6 degrees. The longitude
+// difference is wrapped to [-180, 180) so that values straddling the
+// antimeridian (e.g. 179.9999999 vs -179.9999999, or -180 vs +180) compare
+// as equal, and weighted by cos(lat) so the assertion degenerates gracefully
+// at poles where longitude is geometrically undefined.
+#define EXPECT_NEAR_LatLng(expected, actual)                                            \
+    do {                                                                                \
+        EXPECT_NEAR((expected).lat, (actual).lat, 1e-6);                                \
+        const double _cosLat = std::cos(::geo::detail::deg2rad((expected).lat));        \
+        const double _dLng = ::geo::detail::wrap((expected).lng - (actual).lng,         \
+                                                 -180.0, 180.0);                        \
+        EXPECT_NEAR(_cosLat * _dLng, 0.0, 1e-6)                                         \
+            << "expected lng " << (expected).lng << ", actual lng " << (actual).lng;    \
     } while (false)


### PR DESCRIPTION
## Summary

Four follow-ups from the June code review — no library behavior changes (item 4 only changes behavior on inputs that previously produced NaN).

**1. `kDefaultEpsilon` doc was off by 1000×.** `1e-12` degrees is ~111 nm ≈ 0.1 µm on Earth, not "0.1 nanometers". Fixed in `latlng.hpp` and `docs/api.md`.

**2. `distance_to_segment` approximation documented.** The closest point is found by planar projection in raw `(lat, lng)` coordinate space (same algorithm as android-maps-utils `PolyUtil.distanceToLine`), then the great-circle distance to it is returned:

- longitude is not scaled by `cos(lat)`, so the projection skews at high latitudes — the result can overshoot by a few percent around `lat 80°`;
- longitudes are used as-is, so a segment crossing the antimeridian (`±180°`) is treated as spanning nearly the whole globe — a point lying exactly on such a segment reported ~11 km in the review probe.

Both `poly.hpp` and `docs/api.md` now state this and point tolerance checks at `on_path` (which handles geodesic segments correctly).

**3. `EXPECT_NEAR_LatLng` antimeridian fragility.** The test helper wrapped each longitude independently, so a pair like `179.9999999` vs `-179.9999999` — the same meridian within tolerance — compared as ~360° apart and failed. It now compares the wrapped difference `wrap(expected.lng - actual.lng, -180, 180)` and prints both raw longitudes on failure. Also fixes the stale comment: `wrap()` yields `[-180, 180)`, not `(-180, 180]`.

**4. `hav_from_sin` NaN guard.** Its only caller (`is_on_segment_gc`) passes `sin_dist13 * sin_bearing`, where `sin_bearing` is the quotient `(a·d − b·c)/√((a²+b²)(c²+d²))` — mathematically ≤ 1 by Cauchy–Schwarz, but rounding can push it 1 ulp above 1. Then `sqrt(1 − x²)` of a negative argument returns NaN, every subsequent NaN comparison is `false`, and both rejection checks in `is_on_segment_gc` are silently skipped — `on_path`/`on_edge` (geodesic, their default mode) return a **false positive** for segments under ~2.1 rad of arc. Clamp `x²` to 1 (correct limit `hav(90°) = 0.5`), matching the existing `arc_hav` clamp; regular values are unchanged bit-for-bit.

Measured cost (Apple M1, `-O2`, medians of per-pair deltas across 10 interleaved before/after runs):

| benchmark | Δ | absolute |
|---|---:|---:|
| bare `hav_from_sin` in a tight loop | +20% | **+0.20 ns/call** (0.99 → 1.20 ns; the relative number is large only because the function costs ~1 ns) |
| `on_path` geodesic, worst case: 50-segment full scan, point off path | +3.4% | +1.5 ns/segment |
| everything else | 0% | `hav_from_sin` has no other callers |

## Test plan

- [x] New test `Math.hav_from_sin_clamp`: `±(1 + 1 ulp)` must yield `0.5`, not NaN (fails before the fix)
- [x] Full unit-test suite: 35/35 pass (the `EXPECT_NEAR_LatLng` change is strictly more permissive only at the ±180 boundary and identical elsewhere, so existing assertions keep their strength)