### PR TITLE
Normalize offset/offset_origin output longitude to [-180, 180)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -135,7 +135,7 @@ std::cout << geo::heading(east, equator); // -90 (due west)
 - `distance` — the distance to travel, in meters
 - `heading` — the heading in degrees clockwise from north
 
-Returns: `LatLng` — the destination point.
+Returns: `LatLng` — the destination point. The longitude of the result is normalized to `[-180, 180)`.
 
 ```cpp
 geo::LatLng front{0, 0};
@@ -147,6 +147,9 @@ auto up    = geo::offset(front, quarter,   0); // {  90,    0}
 auto down  = geo::offset(front, quarter, 180); // { -90,    0}
 auto left  = geo::offset(front, quarter, -90); // {   0,  -90}
 auto right = geo::offset(front, quarter,  90); // {   0,   90}
+
+// Crossing the antimeridian: the longitude comes back normalized.
+auto wrapped = geo::offset({0, 170}, 3'000'000, 90); // {0, -163.02}, not {0, 196.98}
 ```
 
 ---
@@ -159,7 +162,7 @@ auto right = geo::offset(front, quarter,  90); // {   0,   90}
 - `distance` — the distance travelled, in meters
 - `heading` — the heading in degrees clockwise from north
 
-Returns: `std::optional<LatLng>` — the origin, or `std::nullopt` if unreachable.
+Returns: `std::optional<LatLng>` — the origin, or `std::nullopt` if unreachable. The longitude of the result is normalized to `[-180, 180)`.
 
 ```cpp
 geo::LatLng start{40.0, -74.0};

--- a/include/geo/spherical.hpp
+++ b/include/geo/spherical.hpp
@@ -45,6 +45,7 @@ namespace geo {
 /**
  * Returns the LatLng resulting from moving a distance from an origin
  * in the specified heading (expressed in degrees clockwise from north).
+ * The longitude of the result is normalized to the range [-180, 180).
  */
 [[nodiscard]] inline LatLng offset(const LatLng& from, double distance, double heading_deg) noexcept {
     distance /= detail::kEarthRadius;
@@ -60,13 +61,16 @@ namespace geo {
         sin_distance * cos_from_lat * std::sin(heading_rad),
         cos_distance - sin_from_lat * sin_lat);
 
+    // from_lng and d_lng are each in [-π, π], so their raw sum spans up to
+    // ±2π; wrap it back into the documented LatLng longitude range.
     return LatLng(detail::rad2deg(std::asin(std::clamp(sin_lat, -1.0, 1.0))),
-                  detail::rad2deg(from_lng + d_lng));
+                  detail::wrap(detail::rad2deg(from_lng + d_lng), -180.0, 180.0));
 }
 
 /**
  * Returns the location of origin when provided with a destination,
  * meters travelled and original heading. Returns nullopt when no solution exists.
+ * The longitude of the result is normalized to the range [-180, 180).
  */
 [[nodiscard]] inline std::optional<LatLng> offset_origin(const LatLng& to, double distance, double heading_deg) noexcept {
     double heading_rad = detail::deg2rad(heading_deg);
@@ -91,7 +95,10 @@ namespace geo {
     if (from_lat_radians < -detail::kPi / 2 || from_lat_radians > detail::kPi / 2) return std::nullopt;
     double from_lng_radians = detail::deg2rad(to.lng) -
         std::atan2(n3, n1 * std::cos(from_lat_radians) - n2 * std::sin(from_lat_radians));
-    return LatLng(detail::rad2deg(from_lat_radians), detail::rad2deg(from_lng_radians));
+    // to.lng - atan2(...) spans up to ±2π; wrap it back into the documented
+    // LatLng longitude range.
+    return LatLng(detail::rad2deg(from_lat_radians),
+                  detail::wrap(detail::rad2deg(from_lng_radians), -180.0, 180.0));
 }
 
 /**

--- a/tests/spherical/offset.hpp
+++ b/tests/spherical/offset.hpp
@@ -4,9 +4,12 @@
 #include "../test_helpers.hpp"
 
 using geo::LatLng;
+using geo::distance_between;
 using geo::offset;
+using geo::detail::deg2rad;
 using geo::detail::kEarthRadius;
 using geo::detail::kPi;
+using geo::detail::rad2deg;
 
 TEST(Spherical, offset) {
     LatLng up    = { 90.0,    0.0 };
@@ -34,4 +37,30 @@ TEST(Spherical, offset) {
     EXPECT_NEAR_LatLng(right, offset(left, kPi * kEarthRadius,      90));
 
     // NOTE: Heading is undefined at the poles, so we do not test from up/down.
+}
+
+TEST(Spherical, offset_lng_normalized) {
+    // The raw result longitude (from_lng + d_lng) spans up to ±360° when the
+    // path crosses the antimeridian; offset must wrap it into [-180, 180)
+    // (the Android SDK normalized in the LatLng constructor, this port does
+    // not, so the function has to wrap its own output).
+    const double d = 3.0e6;  // 3000 km ≈ 26.98° of arc at the equator
+    const double d_deg = rad2deg(d / kEarthRadius);
+
+    // Eastbound across the antimeridian: raw lng ≈ +196.98 → wrapped ≈ -163.02.
+    LatLng east = offset(LatLng(0, 170), d, 90);
+    EXPECT_NEAR(east.lat, 0.0, 1e-9);
+    EXPECT_NEAR(east.lng, 170.0 + d_deg - 360.0, 1e-9);
+
+    // Westbound across the antimeridian: raw lng ≈ -196.98 → wrapped ≈ +163.02.
+    LatLng west = offset(LatLng(0, -170), d, -90);
+    EXPECT_NEAR(west.lat, 0.0, 1e-9);
+    EXPECT_NEAR(west.lng, -170.0 - d_deg + 360.0, 1e-9);
+
+    // Landing exactly on the antimeridian: lng must stay inside [-180, 180),
+    // i.e. +180 becomes -180 (the same point).
+    LatLng on180 = offset(LatLng(0, 170), deg2rad(10.0) * kEarthRadius, 90);
+    EXPECT_GE(on180.lng, -180.0);
+    EXPECT_LT(on180.lng,  180.0);
+    EXPECT_LT(distance_between(on180, LatLng(0, 180)), 1e-3);
 }

--- a/tests/spherical/offset_origin.hpp
+++ b/tests/spherical/offset_origin.hpp
@@ -8,6 +8,7 @@ using geo::offset;
 using geo::offset_origin;
 using geo::detail::kEarthRadius;
 using geo::detail::kPi;
+using geo::detail::rad2deg;
 
 TEST(Spherical, offset_origin) {
     LatLng front = {  0.0,    0.0 };
@@ -72,5 +73,33 @@ TEST(Spherical, offset_origin) {
         auto r = offset_origin(to, half_pi_R, 45.0);
         ASSERT_TRUE(r.has_value());
         EXPECT_NEAR_LatLng(to, offset(r.value(), half_pi_R, 45.0));
+    }
+}
+
+TEST(Spherical, offset_origin_lng_normalized) {
+    // The raw origin longitude (to.lng - atan2(...)) spans up to ±360° when
+    // the origin lies across the antimeridian from the destination; it must
+    // come back wrapped into [-180, 180).
+    const double d = 3.0e6;  // 3000 km ≈ 26.98° of arc at the equator
+    const double d_deg = rad2deg(d / kEarthRadius);
+
+    // Travelling east to (0,-170): the origin lies west across the
+    // antimeridian, raw lng ≈ -196.98 → wrapped ≈ +163.02.
+    {
+        auto r = offset_origin(LatLng(0, -170), d, 90);
+        ASSERT_TRUE(r.has_value());
+        EXPECT_NEAR(r->lat, 0.0, 1e-9);
+        EXPECT_NEAR(r->lng, -170.0 - d_deg + 360.0, 1e-9);
+        // And the wrapped origin still maps back onto the destination.
+        EXPECT_NEAR_LatLng(LatLng(0, -170), offset(r.value(), d, 90));
+    }
+
+    // Travelling west to (0,170): the origin lies east across the
+    // antimeridian, raw lng ≈ +196.98 → wrapped ≈ -163.02.
+    {
+        auto r = offset_origin(LatLng(0, 170), d, -90);
+        ASSERT_TRUE(r.has_value());
+        EXPECT_NEAR(r->lat, 0.0, 1e-9);
+        EXPECT_NEAR(r->lng, 170.0 + d_deg - 360.0, 1e-9);
     }
 }


### PR DESCRIPTION
## Problem

`offset()` and `offset_origin()` return the raw longitude term without wrapping, so any result that crosses the antimeridian leaves the documented LatLng range ("Longitude ranges between -180 and 180 degrees"):

```cpp
geo::offset({0, 170}, 3'000'000, 90);          // lng = +196.9796, expected -163.0204
geo::offset_origin({0, -170}, 3'000'000, 90);  // lng = -196.9796, expected +163.0204
```

- `offset` returns `rad2deg(from_lng + d_lng)` — each term is in `[-π, π]`, the sum spans up to `±2π`.
- `offset_origin` returns `deg2rad(to.lng) - atan2(...)` — same issue.

**Root cause:** the Android SDK normalizes longitude inside the `LatLng` constructor, so android-maps-utils never needed to wrap these results. This port's `constexpr` constructor stores values as-is (`fmod` is not `constexpr` before C++23), so the normalization was silently lost in porting.

Library-internal math is unaffected (everything is periodic, `operator==` compares lng modulo 360), but out-of-range longitudes break interop: GeoJSON (RFC 7946), map APIs, DB range constraints, naive component comparison.

## Fix

Wrap the output longitude with `detail::wrap(lng, -180.0, 180.0)` in both functions (same approach `heading()` already uses for its result). In-range results take the wrap fast path (two comparisons) and are returned **bit-for-bit unchanged**; only out-of-range results pay for two `fmod`s.

| call | before | after |
|---|---|---|
| `offset((0,170), 3000 km, E)` | `+196.9796100648` | `-163.0203899352` |
| `offset((0,-170), 3000 km, W)` | `-196.9796100648` | `+163.0203899352` |
| `offset_origin((0,-170), 3000 km, E)` | `-196.9796100648` | `+163.0203899352` |
| `offset((0,170), 10° arc, E)` — lands exactly on the antimeridian | `+180.0` | `-180.0` (same point) |
| `offset((10,20), 3000 km, NE)` — in range | `41.320625189337278` | `41.320625189337278` (bit-identical) |

## Timings

Apple M1, `-O2`, Google Benchmark; 10 interleaved base/fixed pairs (run order alternating inside each pair), median of per-pair deltas of per-run medians (15 reps each) — robust against drifting background load. 1000 varied calls per iteration.

| benchmark | base ns/call | fixed ns/call | delta |
|---|---|---|---|
| `offset`, result in range (fast path) | 31.9 | 32.6 | **+0.70 ns (+2.2%)** |
| `offset`, result crosses antimeridian | 23.6 | 41.1 | **+17.5 ns (+75%)** |
| `offset_origin`, result in range | 60.4 | 62.5 | **+2.2 ns (+3.6%)** |
| `offset_origin`, result crosses antimeridian | 44.1 | 58.3 | **+14.2 ns (+32%)** |

The crossing-path cost is two `fmod` calls sitting on the critical path right before the return; it only applies to the (previously incorrect) out-of-range results. The headline percentage looks large because the function itself is only tens of nanoseconds.

## Tests

Two new regression tests (suite 34 → 36, all pass):
- `Spherical.offset_lng_normalized` — east/west crossings against analytically derived expected longitudes (1e-9 deg tolerance), plus the exact-180 landing case (`lng ∈ [-180, 180)` and position within 1 mm of `(0, 180)`).
- `Spherical.offset_origin_lng_normalized` — both crossing directions, plus a round-trip back onto the destination.

## Notes

- **Behavior change:** outputs that previously exceeded `[-180, 180]` now come back wrapped (and exact `+180` becomes `-180`, the same point). Suggest releasing as a **minor version (1.1.0)** together with #24/#25/#26 so the distribution channels (vcpkg/xrepo/conan/build2) are re-rolled once.
- `interpolate()`'s linear fallback can still overshoot the range marginally (~1e-7 deg, or for degenerate antipodal inputs); left out of this PR because #24 already touches that exact line — a one-line `detail::wrap` there can ride along with #24 or follow up after it merges.
- `docs/api.md`: both function sections now state the normalized output range, with an antimeridian example under `offset`.