### PR TITLE
Update actions/checkout to v6

### DIFF
--- a/.github/workflows/benchmarks-smoke.yml
+++ b/.github/workflows/benchmarks-smoke.yml
@@ -35,7 +35,7 @@ jobs:
     name: smoke-build (ubuntu)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure
         run: cmake -S . -B build-bench -DGEO_UTILS_CPP_BUILD_BENCHMARKS=ON -DGEO_UTILS_CPP_BUILD_TESTS=OFF -DGEO_UTILS_CPP_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/build2.yml
+++ b/.github/workflows/build2.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install build2 toolchain
         run: brew install build2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       CXX: ${{ matrix.cxx }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache FetchContent dependencies
         uses: actions/cache@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache FetchContent dependencies
         uses: actions/cache@v4

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # CMAKE_INSTALL_PREFIX is set at configure time so it's baked into the
       # generated .pc file; the install step must not pass --prefix or the

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # GH-hosted runners ship vcpkg pre-installed at $VCPKG_INSTALLATION_ROOT.
       # The bundled checkout can lag the registry by days/weeks, so sync to

--- a/.github/workflows/xrepo.yml
+++ b/.github/workflows/xrepo.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup xmake
         uses: xmake-io/github-action-setup-xmake@v1


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v6 in all 7 workflows.
- Why: GitHub [forces Node 24 for actions starting June 16, 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/); `checkout@v4` targets Node 20 and already produces deprecation annotations on every run. v6 (current major, v6.0.3) runs Node 24 natively. We use `checkout` with no inputs, so there are no behavioral differences for us.

## Test plan

- [x] PR checks cover 5 of 7 workflows directly (ci, coverage, install; build2 and benchmarks-smoke trigger via their workflow-file path filters).
- [x] `vcpkg.yml` and `xrepo.yml` are cron/dispatch-only — dispatched manually on this branch to validate (links in PR comments below).