### PR TITLE
Fix contains() for polygon edges spanning exactly 180° of longitude

### DIFF
--- a/include/geo/poly.hpp
+++ b/include/geo/poly.hpp
@@ -49,6 +49,13 @@ namespace detail {
     if (lat1 <= -kPi / 2 || lat2 <= -kPi / 2 || lat1 >= kPi / 2 || lat2 >= kPi / 2) {
         return false;
     }
+    // An edge spanning exactly 180° of longitude (lng2 == -kPi after wrapping)
+    // has an ambiguous direction — two equal great-circle arcs connect its
+    // endpoints. Never count it as an intersection (upstream PolyUtil
+    // convention); without this, tan_lat_gc divides by sin(-π) ≈ -1.2e-16.
+    if (lng2 <= -kPi) {
+        return false;
+    }
     double linear_lat = (lat1 * (lng2 - lng3) + lat2 * lng3) / lng2;
     if (lat1 >= 0 && lat2 >= 0 && lat3 < linear_lat) {
         return false;

--- a/tests/poly/contains.hpp
+++ b/tests/poly/contains.hpp
@@ -79,3 +79,28 @@ TEST(Poly, contains) {
         EXPECT_FALSE(contains(point, poly, false));
     }
 }
+
+TEST(Poly, contains_180deg_edge) {
+    // Edge (10,0)->(-20,180) spans exactly 180° of longitude — its direction
+    // is ambiguous (two equal great-circle arcs), so it never counts as an
+    // intersection of the South-Pole test ray (upstream PolyUtil convention).
+    // Without the lng2 <= -π guard this evaluated tan_lat_gc with
+    // sin(-π) ≈ -1.2e-16 in the denominator, flipping parity arbitrarily.
+    std::vector<LatLng> tri = { {10, 0}, {-20, 180}, {40, 90} };
+    for (const auto & point : { LatLng(0, -90), LatLng(-60, 0) }) {
+        EXPECT_FALSE(contains(point, tri,  true));
+        EXPECT_FALSE(contains(point, tri, false));
+    }
+    EXPECT_TRUE(contains(LatLng(90, 0), tri,  true));
+    EXPECT_TRUE(contains(LatLng(90, 0), tri, false));
+
+    // Degenerate "hemisphere": every edge spans 180°, so no test ray ever
+    // crosses an edge; only vertex matches count as inside.
+    std::vector<LatLng> hemi = { {0, 0}, {0, 180} };
+    for (const auto & point : { LatLng(45, 90), LatLng(45, -90) }) {
+        EXPECT_FALSE(contains(point, hemi,  true));
+        EXPECT_FALSE(contains(point, hemi, false));
+    }
+    EXPECT_TRUE(contains(LatLng(0, 0), hemi,  true));
+    EXPECT_TRUE(contains(LatLng(0, 0), hemi, false));
+}


### PR DESCRIPTION
## Bug

`detail::intersects()` dropped a guard that upstream [PolyUtil has](https://github.com/googlemaps/android-maps-utils/blob/main/library/src/main/java/com/google/maps/android/PolyUtil.kt#L556-L558):

```java
if (lng2 <= -PI) { return false; }
```

`contains()` normalizes every edge so its first endpoint is at longitude 0 and the second at `lng2 = wrap(lng2 - lng1, -π, π)`. When the endpoints are exactly **180° of longitude apart** (e.g. `0 → 180`, `-90 → 90`, `20 → -160` — any pair of "clean" coordinates `X` and `X ± 180`), `wrap` yields exactly `-π`. Such an edge is ambiguous — two equal great-circle arcs connect its endpoints — and upstream's convention is to never count it as an intersection of the South-Pole test ray.

Without the guard the port fell through:

- **geodesic:** `tan_lat_gc` divides by `sin(-π) ≈ -1.2e-16`, producing ±1.5e15 garbage whose comparison flips the ray-casting parity arbitrarily;
- **rhumb:** `mercator_lat_rhumb` returns a deterministic value for a direction upstream never evaluates — silent divergence.

### Impact

Sweep of 35×72 query points against polygons containing one 180°-spanning edge, port vs upstream semantics:

| Polygon | geodesic mismatches | rhumb mismatches |
|---|---|---|
| `{(10,0), (-20,180), (40,90)}` | **1246** / 2448 | 671 / 2448 |
| `{(0,-90), (30,90), (60,0)}` | 11 | 516 |
| `{(-10,20), (15,-160), (5,-60)}` | 14 | 608 |

Minimal repro: `contains({0,-90}, {{10,0},{-20,180},{40,90}})` returned `true`; upstream (and now this port) returns `false`.

## Fix

One early return in `detail::intersects()` after the pole checks, mirroring upstream. Behavior on polygons without 180°-spanning edges is unchanged — verified bit-identical on 3000 benchmark queries (regular polygons of 10/100/1000 vertices).

## Performance

Paired benchmarks (10 interleaved base/fixed runs, median of per-pair deltas, Apple M1):

| Harness | Mode | base | fixed | delta |
|---|---|---|---|---|
| 10 queries × 8-vertex polygon | geodesic | 504.5 ns | 527.4 ns | +5.6% (≈ +2.9 ns/call) |
| 10 queries × 8-vertex polygon | rhumb | 510.5 ns | 540.2 ns | +6.0% (≈ +3.1 ns/call) |
| `BM_GeoUtils_Contains/10` (repo harness) | rhumb | 95.1 µs | 75.2 µs | **-20.3%** |
| `BM_GeoUtils_Contains/100` | rhumb | 580.8 µs | 446.6 µs | **-23.5%** |
| `BM_GeoUtils_Contains/1000` | rhumb | 4.05 ms | 3.95 ms | -2.2% |

The real arithmetic cost is one well-predicted compare per candidate edge (sub-ns); the swings in both directions are compiler inlining/code-layout effects, not algorithmic changes (results are bit-identical). Polygons that do contain 180° edges get strictly faster (early out instead of trig).

## Tests

New `TEST(Poly, contains_180deg_edge)`: the regression triangle above (both modes) plus a degenerate two-point "hemisphere" `{(0,0),(0,180)}` where every edge spans 180°. Suite: 35/35 green.

## Note

Behavior change for affected inputs — worth bundling into the next minor release together with #24–#27.