### PR TITLE
Expand poly test coverage: closing segment, repeated vertex, tolerance

### DIFF
--- a/tests/poly/contains.hpp
+++ b/tests/poly/contains.hpp
@@ -48,7 +48,7 @@ TEST(Poly, contains) {
 
     // Around North Pole.
     std::vector<LatLng> northPole = { {89, 0}, {89, 120}, {89, -120} };
-    for (const auto & point : { LatLng(90, 0), /* LatLng(90, 180), */ LatLng(90, -90) }) {
+    for (const auto & point : { LatLng(90, 0), LatLng(90, 180), LatLng(90, -90) }) {
         EXPECT_TRUE(contains(point, northPole,  true));
         EXPECT_TRUE(contains(point, northPole, false));
     }
@@ -59,7 +59,7 @@ TEST(Poly, contains) {
 
     // Around South Pole.
     std::vector<LatLng> southPole = { {-89, 0}, {-89, 120}, {-89, -120} };
-    for (const auto & point : { LatLng(90, 0), /* LatLng(90, 180), */ LatLng(90, -90), LatLng(0, 0) }) {
+    for (const auto & point : { LatLng(90, 0), LatLng(90, 180), LatLng(90, -90), LatLng(0, 0) }) {
         EXPECT_TRUE(contains(point, southPole,  true));
         EXPECT_TRUE(contains(point, southPole, false));
     }

--- a/tests/poly/on_edge.hpp
+++ b/tests/poly/on_edge.hpp
@@ -108,6 +108,19 @@ TEST(Poly, on_edge) {
     }
 }
 
+TEST(Poly, on_edge_closing_segment) {
+    // The closing segment (0,20)->(0,0) of this triangle runs along the
+    // equator, where great-circle and Rhumb paths coincide. (0,10) lies only
+    // on that closing segment — on_edge must include it (polygon is closed).
+    std::vector<LatLng> triangle = { {0, 0}, {5, 10}, {0, 20} };
+    EXPECT_TRUE(on_edge(LatLng(0, 10), triangle,  true));
+    EXPECT_TRUE(on_edge(LatLng(0, 10), triangle, false));
+
+    // Vertices are on the edge too.
+    EXPECT_TRUE(on_edge(LatLng(0, 0),  triangle,  true));
+    EXPECT_TRUE(on_edge(LatLng(0, 20), triangle, false));
+}
+
 TEST(Poly, on_edge_geodesic_parameter) {
     // A constant-latitude segment is a Rhumb line but not a great circle arc.
     // (60, 15) lies exactly on the Rhumb path between (60,0) and (60,30)

--- a/tests/poly/on_path.hpp
+++ b/tests/poly/on_path.hpp
@@ -108,6 +108,47 @@ TEST(Poly, on_path) {
     }
 }
 
+TEST(Poly, on_path_closing_segment_excluded) {
+    // Same triangle as in on_edge_closing_segment: (0,10) lies only on the
+    // implicit closing segment (0,20)->(0,0), which on_path must NOT include
+    // — that is the only difference between on_path and on_edge.
+    std::vector<LatLng> triangle = { {0, 0}, {5, 10}, {0, 20} };
+    EXPECT_FALSE(on_path(LatLng(0, 10), triangle,  true));
+    EXPECT_FALSE(on_path(LatLng(0, 10), triangle, false));
+
+    // Points on real (non-closing) segments are still found.
+    EXPECT_TRUE(on_path(LatLng(0, 0),  triangle,  true));
+    EXPECT_TRUE(on_path(LatLng(0, 20), triangle, false));
+}
+
+TEST(Poly, on_path_repeated_vertex) {
+    // A zero-length segment (repeated vertex) must neither crash nor match
+    // far-away points (exercises the denom <= 0 branch of sin_delta_bearing).
+    std::vector<LatLng> repeated = { {0, 0}, {0, 5}, {0, 5}, {0, 10} };
+    for (const auto & point : { LatLng(0, 2.5), LatLng(0, 5), LatLng(0, 7.5) }) {
+        EXPECT_TRUE(on_path(point, repeated,  true));
+        EXPECT_TRUE(on_path(point, repeated, false));
+    }
+    EXPECT_FALSE(on_path(LatLng(1, 5), repeated,  true));
+    EXPECT_FALSE(on_path(LatLng(1, 5), repeated, false));
+
+    // Degenerate polyline of two identical points behaves like a single point.
+    std::vector<LatLng> dup = { {7, 3}, {7, 3} };
+    EXPECT_TRUE (on_path(LatLng(7, 3),        dup, true));
+    EXPECT_FALSE(on_path(LatLng(7, 3.000002), dup, true));
+}
+
+TEST(Poly, on_path_tolerance_meters) {
+    // Tolerance is expressed in meters: (0.0081, 5) is ~900.7 m north of the
+    // equator segment, so it is off the path at 500 m but on it at 1000 m.
+    std::vector<LatLng> equator = { {0, 0}, {0, 10} };
+    LatLng point(0.0081, 5);
+    EXPECT_FALSE(on_path(point, equator,  true,  500.0));
+    EXPECT_FALSE(on_path(point, equator, false,  500.0));
+    EXPECT_TRUE (on_path(point, equator,  true, 1000.0));
+    EXPECT_TRUE (on_path(point, equator, false, 1000.0));
+}
+
 TEST(Poly, on_path_geodesic_parameter) {
     // A constant-latitude segment is a Rhumb line but not a great circle arc.
     // (60, 15) lies exactly on the Rhumb path between (60,0) and (60,30)


### PR DESCRIPTION
## Summary

Test-only PR closing coverage gaps found during a library review. No library changes.

- **Re-enable `LatLng(90, 180)` cases** in `contains` tests (pole queried at longitude 180, previously commented out) — verified passing in both geodesic and rhumb modes.
- **Closing segment**: the only behavioral difference between `on_edge` and `on_path` — the implicit closing segment — was untested for polygons of ≥3 vertices. New mirrored tests use a triangle whose closing edge runs along the equator (where great-circle and Rhumb paths coincide): `on_edge` finds a point on it, `on_path` does not.
- **Repeated vertex**: zero-length segments must neither crash nor match far-away points (exercises the `denom <= 0` branch of `sin_delta_bearing`); degenerate two-identical-point polyline behaves like a single point.
- **Tolerance semantics**: first test with a non-default `tolerance` — a point ~900.7 m off an equator segment is rejected at 500 m and accepted at 1000 m, in both modes.

All expectations were verified against the current implementation before being committed (no characterization of buggy behavior — the new cases are mode-independent by construction).

## Test plan

- [x] 38/38 tests green locally (apple-clang, arm64)
- [x] Hunks in `tests/poly/contains.hpp` do not overlap with #29 — both PRs merge independently