### PR TITLE
Fix Windows CI: key FetchContent cache on runner image version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve runner image version (cache key)
+        id: image
+        shell: bash
+        run: echo "version=${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
       - name: Cache FetchContent dependencies
         uses: actions/cache@v4
         with:
           path: build-cmake/_deps
           # Include repo name in the key so a repo rename (which changes the
           # absolute work-dir path baked into FetchContent's subbuild cache)
-          # invalidates stale caches automatically.
-          key: ${{ runner.os }}-${{ matrix.name }}-${{ github.event.repository.name }}-googletest-1.14.0
+          # invalidates stale caches automatically. Include the runner image
+          # version so a toolchain bump (e.g. Windows switching its default
+          # generator from "Visual Studio 17 2022" to "18 2026") invalidates the
+          # cached googletest subbuild, which otherwise trips CMake's
+          # generator-mismatch check.
+          key: ${{ runner.os }}-${{ matrix.name }}-${{ github.event.repository.name }}-img${{ steps.image.outputs.version }}-googletest-1.14.0
 
       - name: Configure
         run: cmake -S . -B build-cmake -DGEO_UTILS_CPP_BUILD_TESTS=ON -DGEO_UTILS_CPP_BUILD_EXAMPLES=ON

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,14 +32,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve runner image version (cache key)
+        id: image
+        shell: bash
+        run: echo "version=${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
       - name: Cache FetchContent dependencies
         uses: actions/cache@v4
         with:
           path: build-cmake/_deps
           # Include repo name in the key so a repo rename (which changes the
           # absolute work-dir path baked into FetchContent's subbuild cache)
-          # invalidates stale caches automatically.
-          key: ${{ runner.os }}-coverage-${{ github.event.repository.name }}-googletest-1.14.0
+          # invalidates stale caches automatically. Include the runner image
+          # version so a toolchain bump invalidates the cached googletest
+          # subbuild instead of tripping CMake's generator/compiler checks.
+          key: ${{ runner.os }}-coverage-${{ github.event.repository.name }}-img${{ steps.image.outputs.version }}-googletest-1.14.0
 
       - name: Install gcovr
         run: pip install gcovr


### PR DESCRIPTION
## Summary
- The `windows-latest` runner image bumped its default CMake generator from **Visual Studio 17 2022** to **18 2026** (MSVC 19.51). The `_deps` FetchContent cache key was toolchain-agnostic, so the stale googletest **subbuild** (whose `CMakeCache.txt` recorded the old generator) was restored and tripped CMake's `generator ... Does not match the generator used previously` check during configure — failing the Windows leg on master.
- Fix: include the runner `ImageVersion` in the cache key, so any toolchain/image bump invalidates the cache automatically. Applied to `ci.yml` and `coverage.yml` (same `_deps` caching scheme).

## Notes
- First run per OS after merge is an expected cache miss (rebuilds googletest), then caches normally.
- `ImageVersion` is a runner-set env var (not user input) read as a shell variable — no workflow-injection surface.

## Test plan
- [ ] CI green on all legs (esp. **windows**) for this PR
- [ ] Confirm the Cache step reports a miss on first run, hit on a re-run