### PR TITLE
Add ASan/UBSan CI job and a libFuzzer smoke test for decode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@
 #   - macOS  (AppleClang)
 #   - Windows (MSVC)
 #
+# Two extra Ubuntu/clang jobs:
+#   - sanitizers: the same test suite under ASan + UBSan
+#   - fuzz-smoke: a short libFuzzer run over geo::decode
+#
 # Triggered automatically on push/PR to master/main; can also be run manually
 # from the Actions tab in GitHub UI.
 
@@ -80,3 +84,54 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build-cmake -C Release --output-on-failure
+
+  # The full test suite under AddressSanitizer + UndefinedBehaviorSanitizer.
+  # -fno-sanitize-recover=all turns any UB report into a test failure.
+  sanitizers:
+    name: ubuntu-clang-asan-ubsan
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure
+        run: >
+          cmake -S . -B build-san
+          -DGEO_UTILS_CPP_BUILD_TESTS=ON -DGEO_UTILS_CPP_BUILD_EXAMPLES=ON
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -g"
+          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+      - name: Build
+        run: cmake --build build-san -j
+
+      - name: Test
+        run: ctest --test-dir build-san --output-on-failure
+        env:
+          UBSAN_OPTIONS: print_stacktrace=1
+
+  # Short libFuzzer run over geo::decode (the only parser of untrusted
+  # input): memory safety under ASan/UBSan plus the encode/decode
+  # round-trip property. A smoke check, not a soak — 60 seconds.
+  fuzz-smoke:
+    name: fuzz-decode-smoke
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure
+        run: >
+          cmake -S . -B build-fuzz
+          -DGEO_UTILS_CPP_BUILD_TESTS=OFF -DGEO_UTILS_CPP_BUILD_EXAMPLES=OFF
+          -DGEO_UTILS_CPP_BUILD_FUZZERS=ON
+
+      - name: Build
+        run: cmake --build build-fuzz -j
+
+      - name: Fuzz
+        run: ./build-fuzz/tests/fuzz/geo_utils_cpp_fuzz_decode -max_total_time=60 -print_final_stats=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include(CMakeDependentOption)
 option(GEO_UTILS_CPP_BUILD_TESTS      "Build geo-utils-cpp tests"      ${_geo_utils_cpp_is_top_level})
 option(GEO_UTILS_CPP_BUILD_EXAMPLES   "Build geo-utils-cpp examples"   ${_geo_utils_cpp_is_top_level})
 option(GEO_UTILS_CPP_BUILD_BENCHMARKS "Build geo-utils-cpp benchmarks" OFF)
+option(GEO_UTILS_CPP_BUILD_FUZZERS    "Build geo-utils-cpp libFuzzer targets (Clang only)" OFF)
 cmake_dependent_option(GEO_UTILS_CPP_ENABLE_COVERAGE
     "Enable gcov coverage instrumentation (GCC/Clang only)" OFF
     "GEO_UTILS_CPP_BUILD_TESTS" OFF)
@@ -92,6 +93,11 @@ if(GEO_UTILS_CPP_BUILD_TESTS)
         target_compile_options(geo_utils_cpp_tests PRIVATE --coverage)
         target_link_options(geo_utils_cpp_tests PRIVATE --coverage)
     endif()
+endif()
+
+# Fuzzers (opt-in: libFuzzer smoke tests, Clang only)
+if(GEO_UTILS_CPP_BUILD_FUZZERS)
+    add_subdirectory(tests/fuzz)
 endif()
 
 # Examples

--- a/include/geo/encoding.hpp
+++ b/include/geo/encoding.hpp
@@ -102,7 +102,12 @@ template <typename Path>
         const auto r = static_cast<std::int32_t>(result);
         // r >> 1 on a negative value is an arithmetic shift on every
         // supported compiler; C++20 makes that guarantee standard.
-        coord += (r & 1) != 0 ? ~(r >> 1) : (r >> 1);
+        const std::int32_t delta = (r & 1) != 0 ? ~(r >> 1) : (r >> 1);
+        // Accumulate with unsigned wrap-around: malformed input can push the
+        // sum past INT32_MAX, which would be signed-overflow UB. Wrapping
+        // matches the Java original's int semantics.
+        coord = static_cast<std::int32_t>(
+            static_cast<std::uint32_t>(coord) + static_cast<std::uint32_t>(delta));
         return true;
     };
 

--- a/tests/encoding/decode.hpp
+++ b/tests/encoding/decode.hpp
@@ -31,6 +31,20 @@ TEST(Encoding, decode) {
     EXPECT_TRUE(cut_after_lat[0].approx_equal(LatLng(38.5, -120.2), 1e-9));
 }
 
+TEST(Encoding, decode_adversarial_overflow) {
+    // Malformed input with three consecutive lat deltas of +2^30-1: the raw
+    // sum exceeds INT32_MAX. Decoding must stay well-defined (unsigned
+    // wrap-around, matching the Java original) — under UBSan this test used
+    // to abort with signed-overflow UB. Coordinates are unspecified for
+    // malformed input; only the point count and termination are guaranteed.
+    std::string adversarial;
+    for (int i = 0; i < 3; ++i) {
+        geo::detail::encode_value(0x3FFFFFFF, adversarial);  // lat delta
+        geo::detail::encode_value(0, adversarial);           // lng delta
+    }
+    EXPECT_EQ(decode(adversarial).size(), 3U);
+}
+
 TEST(Encoding, encode_decode_roundtrip) {
     std::vector<LatLng> path = {
         {0, 0}, {90, 180}, {-90, -180}, {1.00001, -1.00001},

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,0 +1,16 @@
+# libFuzzer-based fuzz targets. -fsanitize=fuzzer is a Clang driver feature;
+# fail fast on other compilers instead of at link time. Note: on macOS the
+# Command Line Tools clang compiles the flag but ships no libFuzzer runtime
+# (libclang_rt.fuzzer_osx.a) — use a full Xcode toolchain or LLVM clang.
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR
+        "GEO_UTILS_CPP_BUILD_FUZZERS=ON requires Clang (libFuzzer); "
+        "the current compiler is ${CMAKE_CXX_COMPILER_ID}.")
+endif()
+
+add_executable(geo_utils_cpp_fuzz_decode fuzz_decode.cpp)
+target_link_libraries(geo_utils_cpp_fuzz_decode PRIVATE geo::utils)
+target_compile_options(geo_utils_cpp_fuzz_decode PRIVATE
+    -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=all -O1 -g)
+target_link_options(geo_utils_cpp_fuzz_decode PRIVATE
+    -fsanitize=fuzzer,address,undefined)

--- a/tests/fuzz/fuzz_decode.cpp
+++ b/tests/fuzz/fuzz_decode.cpp
@@ -1,0 +1,46 @@
+// Copyright 2026 Aleksandr Kovalko
+// Licensed under the Apache License, Version 2.0
+//
+// libFuzzer harness for geo::decode. Two properties on arbitrary input:
+//  - decoding is memory-safe and free of undefined behavior (enforced by
+//    ASan/UBSan, which the target is always built with);
+//  - re-encoding what was decoded preserves the point count, and — when
+//    every decoded point is a plausible coordinate — reproduces the points
+//    exactly, since decoded points lie on the 1e-5-degree grid.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <geo/encoding.hpp>
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size) {
+    const std::string_view input(reinterpret_cast<const char*>(data), size);
+    const std::vector<geo::LatLng> decoded = geo::decode(input);
+
+    const std::string reencoded = geo::encode(decoded);
+    const std::vector<geo::LatLng> redecoded = geo::decode(reencoded);
+    if (redecoded.size() != decoded.size()) {
+        std::abort();
+    }
+
+    // Malformed input can decode to coordinate jumps beyond the format's
+    // 32-bit delta range, which do not survive re-encoding; the exact
+    // round-trip is only guaranteed for plausible coordinates.
+    bool all_valid = true;
+    for (const auto& point : decoded) {
+        all_valid = all_valid && point.is_valid();
+    }
+    if (all_valid) {
+        for (std::size_t i = 0; i < decoded.size(); ++i) {
+            // Exact comparison on purpose: both sides are int32 * 1e-5.
+            if (decoded[i].lat != redecoded[i].lat || decoded[i].lng != redecoded[i].lng) {
+                std::abort();
+            }
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
## What

Two new Ubuntu/clang jobs in `ci.yml`:
- **sanitizers** — the full test suite under ASan + UBSan (`-fno-sanitize-recover=all`: any UB report fails the job);
- **fuzz-smoke** — a 60-second libFuzzer run over `geo::decode`, the only parser of untrusted input in the library.

The harness lives in `tests/fuzz/` behind a new opt-in `GEO_UTILS_CPP_BUILD_FUZZERS` option (Clang only). Besides memory safety it checks a round-trip property: re-encoding decoded points always preserves the count, and reproduces the points exactly when all of them are plausible coordinates (`is_valid`) — malformed input can decode to coordinate jumps beyond the format's 32-bit delta range, which legitimately don't survive re-encoding.

## Found (and fixed) by the harness before it even landed

The first commit fixes real UB the fuzzer immediately exposes: the per-point delta accumulator in `decode` is an `int32`, and each decoded delta can reach ±2³⁰ — a 24-byte ASCII string (`}~~~~~@?}~~~~~@?}~~~~~@?`) drives the sum past `INT32_MAX`:

```
encoding.hpp:105: runtime error: signed integer overflow: 2147483646 + 1073741823
```

The fix accumulates through `uint32` with well-defined wrap-around — bit-for-bit the Java original's `int` semantics, so well-formed input decodes identically; malformed input keeps yielding unspecified (but now UB-free) coordinates, exactly as `decode`'s docs promise. Regression test included.

## Verification

- 54/54 unit tests green, plain and under ASan/UBSan (macOS, AppleClang);
- the harness compiled against the pre-fix header aborts on the adversarial seed; against the fixed header it runs clean on that seed and the reference polyline;
- the real libFuzzer run happens in the new `fuzz-smoke` job on this PR (macOS Command Line Tools ship no libFuzzer runtime — noted in `tests/fuzz/CMakeLists.txt`).