### PR TITLE
Add closest_point_on_segment and closest_point_on_path (snap to route)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Earth approximation model.
 
 - **Lat/lng-native API** — pass latitude/longitude coordinates directly, no
   framework-specific point types to convert through.
-- **Header-only, dependency-free** — about 34 KB across 6 headers; nothing
+- **Header-only, dependency-free** — about 40 KB across 6 headers; nothing
   to build or link.
 - **Spherical math** — distance, heading, offset, interpolation, area.
-- **Polygon utilities** — point-in-polygon, path proximity, and
-  Douglas–Peucker simplification.
+- **Polygon utilities** — point-in-polygon, path proximity, snap-to-route
+  (`closest_point_on_path`), and Douglas–Peucker simplification.
 - **Polyline encoding** — `encode`/`decode` for the Google Encoded Polyline
   format.
 - **Fast** — matches hand-written haversine on `distance`; especially strong

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,14 +15,15 @@ are internal and not part of the supported API.
 - **Thread safety.** All functions are pure (no global mutable state, no
   caching) and safe to call concurrently from multiple threads.
 - **Error handling.** Scalar functions (`heading`, `offset`,
-  `interpolate`, `distance_between`, `distance_to_segment`) are
-  `noexcept`. Out-of-domain inputs are not asserted: `interpolate` with
+  `interpolate`, `distance_between`, `distance_to_segment`,
+  `closest_point_on_segment`) are `noexcept`. Out-of-domain inputs are not asserted: `interpolate` with
   `fraction` outside `[0, 1]` extrapolates along the great circle,
   `offset_origin` returns `std::nullopt` when no origin can be computed,
   and pathological inputs may yield NaN. Coordinates are never validated —
   an out-of-range `LatLng` gives unspecified (but memory-safe) results;
   see [LatLng § Validation](#validation). Container-taking functions
-  (`area`, `path_length`, `contains`, `on_edge`, `on_path`) are not
+  (`area`, `path_length`, `contains`, `on_edge`, `on_path`,
+  `closest_point_on_path`) are not
   marked `noexcept` because the generic `Path` contract doesn't
   constrain `operator[]` / `size()` to be `noexcept`; they don't throw
   themselves. `encode`, `decode`, and `simplify` return owning
@@ -99,7 +100,8 @@ a.approx_equal(b, 1e-5);   // true (1e-5° ≈ 1 m on equator)
 A series of connected coordinates in an ordered sequence.
 
 `Path` is a template parameter accepted by `path_length`, `area`, `signed_area`,
-`contains`, `on_edge`, `on_path`, `is_closed_polygon`, `simplify`, and `encode`.
+`contains`, `on_edge`, `on_path`, `closest_point_on_path`, `is_closed_polygon`,
+`simplify`, and `encode`.
 It must be a random-access container of `geo::LatLng` — specifically, it must
 support:
 
@@ -402,7 +404,9 @@ Returns: `double` — distance in meters, always ≥ 0.
 > percent at high latitudes (around `lat 80°`); and longitudes are used as-is,
 > so segments crossing the antimeridian (`±180°`) yield meaningless results —
 > a point lying exactly on such a segment can report kilometers of distance.
-> For tolerance checks against true geodesic segments, use `on_path`.
+> For tolerance checks against true geodesic segments, use `on_path`; for the
+> geodesically correct closest point and distance, use
+> `closest_point_on_segment` / `closest_point_on_path`.
 
 ```cpp
 geo::LatLng start{28.05359, -82.41632};
@@ -411,6 +415,71 @@ geo::LatLng point{28.05342, -82.41594};
 
 // Point lies ~38 m east-northeast of the segment
 std::cout << geo::distance_to_segment(point, start, end);
+```
+
+---
+
+### closest_point_on_segment
+
+**`geo::closest_point_on_segment(const LatLng& p, const LatLng& start, const LatLng& end)`** — Returns the point of the great-circle segment `[start, end]` closest to `p`.
+
+The geodesically correct counterpart of `distance_to_segment`: the segment is
+the minor great-circle arc between its endpoints, computed via 3D vector
+projection with no planar approximation — accurate at any latitude and across
+the antimeridian. The distance from `p` to the segment is
+`distance_between(p, closest_point_on_segment(p, start, end))`.
+
+Conventions:
+
+- When the closest point is a segment endpoint, that endpoint is returned
+  with its coordinates exactly as given.
+- Equal (`operator==`) endpoints yield `start`.
+- Antipodal endpoints do not define a unique great circle; the nearer
+  endpoint is returned (the same ambiguity `contains` resolves for
+  180°-spanning edges).
+
+Returns: `LatLng` — the closest point of the segment.
+
+```cpp
+geo::LatLng a{0, 0};
+geo::LatLng b{0, 90};
+
+geo::closest_point_on_segment({20, 30}, a, b);  // {0, 30} — perpendicular foot
+geo::closest_point_on_segment({10, -20}, a, b); // {0, 0}  — beyond start, endpoint returned
+
+// Across the antimeridian (meaningless for distance_to_segment):
+geo::closest_point_on_segment({5, 180}, {0, 170}, {0, -170}); // {0, 180}
+```
+
+---
+
+### closest_point_on_path
+
+**`geo::closest_point_on_path(const LatLng& point, const Path& path)`** — Projects the point onto the closest of the path's great-circle segments — "snap to route". Returns `std::nullopt` for an empty path.
+
+The result is a `geo::PathProjection`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `point` | `LatLng` | the closest point of the path |
+| `segment` | `std::size_t` | index `i`: the point lies on the segment `path[i]` → `path[i + 1]` (`0` for a single-point path) |
+| `distance` | `double` | great-circle distance to `point` in meters; always equals `distance_between(point, result.point)` |
+
+Segments are minor great-circle arcs, as in `on_path(geodesic = true)`. If
+several segments are equally close — typically when the closest point is a
+shared vertex — the lowest segment index wins, and vertex coordinates are
+returned exactly as given. Complexity is O(n) in the number of vertices.
+
+Returns: `std::optional<PathProjection>` — the projection, or `std::nullopt` for an empty path.
+
+```cpp
+std::vector<geo::LatLng> route = { {0, 0}, {0, 10}, {10, 10} };
+geo::LatLng gps{8.0, 9.5};  // a GPS fix near the second leg
+
+auto snapped = geo::closest_point_on_path(gps, route);
+// snapped->segment  == 1
+// snapped->point    ≈ {8.0, 10}
+// snapped->distance ≈ 55 km
 ```
 
 ---

--- a/include/geo/poly.hpp
+++ b/include/geo/poly.hpp
@@ -16,6 +16,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <limits>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -119,6 +121,77 @@ namespace detail {
     double hav_along_track23 = (hav_dist23 - hav_cross_track) / cos_cross_track;
     double sin_sum_along_track = sin_sum_from_hav(hav_along_track13, hav_along_track23);
     return sin_sum_along_track > 0;
+}
+
+// A direction on the unit sphere in Cartesian coordinates.
+struct Vec3 {
+    double x;
+    double y;
+    double z;
+};
+
+[[nodiscard]] inline Vec3 to_unit_vec(const LatLng& point) noexcept {
+    double lat = deg2rad(point.lat);
+    double lng = deg2rad(point.lng);
+    double cos_lat = std::cos(lat);
+    return {cos_lat * std::cos(lng), cos_lat * std::sin(lng), std::sin(lat)};
+}
+
+// Scale-invariant: v does not have to be normalized.
+[[nodiscard]] inline LatLng vec_to_latlng(const Vec3& v) noexcept {
+    return LatLng(rad2deg(std::atan2(v.z, std::sqrt(v.x * v.x + v.y * v.y))),
+                  rad2deg(std::atan2(v.y, v.x)));
+}
+
+[[nodiscard]] inline Vec3 cross(const Vec3& u, const Vec3& v) noexcept {
+    return {u.y * v.z - u.z * v.y,
+            u.z * v.x - u.x * v.z,
+            u.x * v.y - u.y * v.x};
+}
+
+[[nodiscard]] inline double dot(const Vec3& u, const Vec3& v) noexcept {
+    return u.x * v.x + u.y * v.y + u.z * v.z;
+}
+
+// Angle between two directions, in radians. Scale-invariant and, unlike an
+// acos of the dot product, stable for both small and near-pi angles.
+[[nodiscard]] inline double vec_angle(const Vec3& u, const Vec3& v) noexcept {
+    Vec3 c = cross(u, v);
+    return std::atan2(std::sqrt(dot(c, c)), dot(u, v));
+}
+
+// Which point of the minor great-circle arc a->b is closest to p: the
+// perpendicular projection of p onto the arc's great circle (written to proj,
+// not normalized), or one of the endpoints. All inputs are unit vectors.
+enum class ArcNearest { kProjection, kStart, kEnd };
+
+[[nodiscard]] inline ArcNearest nearest_on_arc(const Vec3& a, const Vec3& b, const Vec3& p, Vec3& proj) noexcept {
+    // The nearer endpoint (larger dot product == smaller angle) is also the
+    // endpoint nearer to the projection along the circle, so it doubles as
+    // the answer whenever the projection falls outside the arc.
+    const Vec3 n = cross(a, b);
+    const double n2 = dot(n, n);
+    // n2 == sin^2(arc length). Degenerate arcs — endpoints closer than
+    // ~1e-12 rad or that close to antipodal — have no usable great-circle
+    // normal: for identical endpoints the arc is a point, for antipodal ones
+    // the connecting great circle is not unique (same ambiguity contains()
+    // resolves for 180-degree edges by convention). Use the nearer endpoint.
+    if (n2 <= 1e-24) {
+        return dot(p, a) >= dot(p, b) ? ArcNearest::kStart : ArcNearest::kEnd;
+    }
+    const double k = dot(p, n) / n2;
+    proj = {p.x - k * n.x, p.y - k * n.y, p.z - k * n.z};
+    // p at a pole of the great circle: the whole circle is 90 degrees away,
+    // so the nearer endpoint is as close as any point of the arc.
+    if (dot(proj, proj) <= 1e-24) {
+        return dot(p, a) >= dot(p, b) ? ArcNearest::kStart : ArcNearest::kEnd;
+    }
+    // proj lies within the minor arc iff it is on b's side of the plane
+    // spanned by a and n, and on a's side of the plane spanned by b and n.
+    if (dot(cross(a, proj), n) >= 0 && dot(cross(proj, b), n) >= 0) {
+        return ArcNearest::kProjection;
+    }
+    return dot(p, a) >= dot(p, b) ? ArcNearest::kStart : ArcNearest::kEnd;
 }
 
 // Computes whether a given point lies on or near a polyline within a tolerance.
@@ -281,6 +354,107 @@ template <typename Path>
     }
     LatLng su(start.lat + u * (end.lat - start.lat), start.lng + u * (end.lng - start.lng));
     return distance_between(p, su);
+}
+
+/**
+ * Returns the point of the great-circle segment [start, end] closest to p.
+ *
+ * The geodesically correct counterpart of distance_to_segment: the segment is
+ * the minor great-circle arc between its endpoints, with no planar
+ * approximation — accurate at any latitude and across the antimeridian. The
+ * distance from p to the segment is distance_between(p, closest_point_on_segment(...)).
+ *
+ * Conventions: when the closest point is a segment endpoint, that endpoint is
+ * returned with its coordinates exactly as given. Equal (operator==)
+ * endpoints yield start. Antipodal endpoints do not define a unique great
+ * circle — the nearer endpoint is returned.
+ */
+[[nodiscard]] inline LatLng closest_point_on_segment(const LatLng& p, const LatLng& start, const LatLng& end) noexcept {
+    if (start == end) {
+        return start;
+    }
+    detail::Vec3 proj{0.0, 0.0, 0.0};
+    const detail::ArcNearest nearest = detail::nearest_on_arc(
+        detail::to_unit_vec(start), detail::to_unit_vec(end), detail::to_unit_vec(p), proj);
+    if (nearest == detail::ArcNearest::kStart) {
+        return start;
+    }
+    if (nearest == detail::ArcNearest::kEnd) {
+        return end;
+    }
+    return detail::vec_to_latlng(proj);
+}
+
+/**
+ * The result of projecting a point onto a path: the closest point, the index
+ * of the segment it lies on (from path[segment] to path[segment + 1]; 0 for
+ * a single-point path), and the great-circle distance to it in meters —
+ * always equal to distance_between(point, result.point).
+ */
+struct PathProjection {
+    LatLng point;
+    std::size_t segment;
+    double distance;
+};
+
+/**
+ * Projects the point onto the closest of the path's great-circle segments
+ * ("snap to route"). Segments are minor great-circle arcs, as in
+ * on_path(geodesic = true), and the result is geodesically correct at any
+ * latitude and across the antimeridian — unlike distance_to_segment.
+ *
+ * Returns std::nullopt for an empty path. When several segments are equally
+ * close — typically when the closest point is a shared vertex — the lowest
+ * segment index wins. O(n) in the number of vertices.
+ */
+template <typename Path>
+[[nodiscard]] std::optional<PathProjection> closest_point_on_path(const LatLng& point, const Path& path) {
+    const std::size_t size = path.size();
+    if (size == 0) {
+        return std::nullopt;
+    }
+    const LatLng first(path[0].lat, path[0].lng);
+    if (size == 1) {
+        return PathProjection{first, 0, distance_between(point, first)};
+    }
+
+    // Vertices are converted once and shared between adjacent segments, so
+    // equally-close candidates at a shared vertex compare bit-identically and
+    // the strict < keeps the earliest segment.
+    const detail::Vec3 p = detail::to_unit_vec(point);
+    detail::Vec3 prev = detail::to_unit_vec(first);
+
+    double best_angle = std::numeric_limits<double>::infinity();
+    std::size_t best_segment = 0;
+    detail::ArcNearest best_nearest = detail::ArcNearest::kStart;
+    detail::Vec3 best_proj{0.0, 0.0, 0.0};
+
+    for (std::size_t i = 1; i < size; ++i) {
+        const detail::Vec3 cur = detail::to_unit_vec(LatLng(path[i].lat, path[i].lng));
+        detail::Vec3 proj{0.0, 0.0, 0.0};
+        const detail::ArcNearest nearest = detail::nearest_on_arc(prev, cur, p, proj);
+        const detail::Vec3& candidate =
+            nearest == detail::ArcNearest::kProjection ? proj
+            : nearest == detail::ArcNearest::kStart    ? prev
+                                                       : cur;
+        const double angle = detail::vec_angle(p, candidate);
+        if (angle < best_angle) {
+            best_angle = angle;
+            best_segment = i - 1;
+            best_nearest = nearest;
+            best_proj = proj;
+        }
+        prev = cur;
+    }
+
+    // Endpoint results reuse the original vertex coordinates exactly.
+    const LatLng best_point =
+        best_nearest == detail::ArcNearest::kStart
+            ? LatLng(path[best_segment].lat, path[best_segment].lng)
+        : best_nearest == detail::ArcNearest::kEnd
+            ? LatLng(path[best_segment + 1].lat, path[best_segment + 1].lng)
+            : detail::vec_to_latlng(best_proj);
+    return PathProjection{best_point, best_segment, distance_between(point, best_point)};
 }
 
 /**

--- a/tests/poly/closest_point_on_path.hpp
+++ b/tests/poly/closest_point_on_path.hpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include <geo/poly.hpp>
+#include "../test_helpers.hpp"
+
+using geo::LatLng;
+using geo::closest_point_on_path;
+using geo::distance_between;
+
+TEST(Poly, closest_point_on_path) {
+    // Empty path: no closest point.
+    std::vector<LatLng> empty;
+    EXPECT_FALSE(closest_point_on_path(LatLng(0, 0), empty).has_value());
+
+    // Single point: the point itself, segment index 0.
+    std::vector<LatLng> one = { {45, 45} };
+    auto r1 = closest_point_on_path(LatLng(0, 0), one);
+    ASSERT_TRUE(r1.has_value());
+    EXPECT_EQ(r1->point.lat, 45.0);
+    EXPECT_EQ(r1->point.lng, 45.0);
+    EXPECT_EQ(r1->segment, 0U);
+    EXPECT_DOUBLE_EQ(r1->distance, distance_between(LatLng(0, 0), r1->point));
+
+    // An L-shaped route: equator leg, then a meridian leg.
+    std::vector<LatLng> route = { {0, 0}, {0, 10}, {10, 10} };
+
+    // Clearly nearest to the first leg.
+    auto r2 = closest_point_on_path(LatLng(2, 5), route);
+    ASSERT_TRUE(r2.has_value());
+    EXPECT_EQ(r2->segment, 0U);
+    EXPECT_NEAR_LatLng(LatLng(0, 5), r2->point);
+    EXPECT_DOUBLE_EQ(r2->distance, distance_between(LatLng(2, 5), r2->point));
+
+    // Clearly nearest to the second leg: the foot keeps ~the latitude.
+    auto r3 = closest_point_on_path(LatLng(8, 9.5), route);
+    ASSERT_TRUE(r3.has_value());
+    EXPECT_EQ(r3->segment, 1U);
+    EXPECT_NEAR(r3->point.lng, 10.0, 1e-9);
+    EXPECT_NEAR(r3->point.lat, 8.0, 0.01);
+    EXPECT_DOUBLE_EQ(r3->distance, distance_between(LatLng(8, 9.5), r3->point));
+
+    // A point of the route itself: distance ~0, first matching segment.
+    auto r4 = closest_point_on_path(geo::interpolate(route[0], route[1], 0.3), route);
+    ASSERT_TRUE(r4.has_value());
+    EXPECT_EQ(r4->segment, 0U);
+    EXPECT_LT(r4->distance, 1e-6);
+}
+
+TEST(Poly, closest_point_on_path_shared_vertex_tie) {
+    // Both legs are closest at their shared vertex: the tie goes to the
+    // lower segment index, and the vertex coordinates come back bit-exact.
+    std::vector<LatLng> route = { {0, 0}, {0, 10}, {10, 10} };
+    auto r = closest_point_on_path(LatLng(-5, 15), route);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->segment, 0U);
+    EXPECT_EQ(r->point.lat, 0.0);
+    EXPECT_EQ(r->point.lng, 10.0);
+    EXPECT_DOUBLE_EQ(r->distance, distance_between(LatLng(-5, 15), r->point));
+}
+
+TEST(Poly, closest_point_on_path_antimeridian) {
+    // Route crossing the antimeridian; the probe sits right on lng 180.
+    std::vector<LatLng> route = { {0, 170}, {0, -170}, {5, -170} };
+    auto r = closest_point_on_path(LatLng(1, 180), route);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->segment, 0U);
+    EXPECT_NEAR_LatLng(LatLng(0, 180), r->point);
+    EXPECT_NEAR(r->distance, geo::detail::deg2rad(1.0) * geo::detail::kEarthRadius, 1e-3);
+}

--- a/tests/poly/closest_point_on_segment.hpp
+++ b/tests/poly/closest_point_on_segment.hpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include <geo/poly.hpp>
+#include "../test_helpers.hpp"
+
+using geo::LatLng;
+using geo::closest_point_on_segment;
+using geo::distance_between;
+using geo::distance_to_segment;
+
+TEST(Poly, closest_point_on_segment) {
+    const LatLng a(0, 0);
+    const LatLng b(0, 90);
+
+    // A point on the segment maps to itself.
+    EXPECT_NEAR_LatLng(LatLng(0, 45), closest_point_on_segment(LatLng(0, 45), a, b));
+
+    // Perpendicular foot: on the equator the closest point keeps the
+    // longitude, from either side.
+    EXPECT_NEAR_LatLng(LatLng(0, 30), closest_point_on_segment(LatLng( 20, 30), a, b));
+    EXPECT_NEAR_LatLng(LatLng(0, 30), closest_point_on_segment(LatLng(-20, 30), a, b));
+
+    // Projection falls outside the arc: the nearer endpoint is returned,
+    // with its coordinates bit-exact.
+    LatLng before = closest_point_on_segment(LatLng(10, -20), a, b);
+    EXPECT_EQ(before.lat, a.lat);
+    EXPECT_EQ(before.lng, a.lng);
+    LatLng after = closest_point_on_segment(LatLng(-10, 100), a, b);
+    EXPECT_EQ(after.lat, b.lat);
+    EXPECT_EQ(after.lng, b.lng);
+
+    // Degenerate segment: start == end yields start.
+    LatLng same = closest_point_on_segment(LatLng(0, 0), LatLng(45, 45), LatLng(45, 45));
+    EXPECT_EQ(same.lat, 45.0);
+    EXPECT_EQ(same.lng, 45.0);
+
+    // Antipodal endpoints: no unique great circle — the nearer endpoint.
+    LatLng anti = closest_point_on_segment(LatLng(10, 20), LatLng(0, 0), LatLng(0, 180));
+    EXPECT_EQ(anti.lat, 0.0);
+    EXPECT_EQ(anti.lng, 0.0);
+
+    // Point at a pole of the segment's great circle: the whole circle is a
+    // quarter-circumference away, so an endpoint is a correct answer.
+    LatLng pole = closest_point_on_segment(LatLng(90, 0), a, b);
+    EXPECT_EQ(pole.lat, a.lat);
+    EXPECT_EQ(pole.lng, a.lng);
+    EXPECT_NEAR(distance_between(LatLng(90, 0), pole),
+                geo::detail::kPi / 2 * geo::detail::kEarthRadius, 1e-3);
+}
+
+TEST(Poly, closest_point_on_segment_high_latitude) {
+    // The great circle between two points at latitude 80 bulges poleward:
+    // its vertex latitude is atan(tan(80°) / cos(45°)) ≈ 82.89°, not 80.
+    // The planar distance_to_segment misses this entirely (it projects in
+    // raw lat/lng space and snaps to an endpoint here).
+    const LatLng a(80, 0);
+    const LatLng b(80, 90);
+    const LatLng pole(90, 0);
+
+    LatLng c = closest_point_on_segment(pole, a, b);
+    double peak_lat = geo::detail::rad2deg(
+        std::atan(std::tan(geo::detail::deg2rad(80.0)) / std::cos(geo::detail::deg2rad(45.0))));
+    EXPECT_NEAR(c.lat, peak_lat, 1e-9);  // ≈ 82.8935
+    EXPECT_NEAR(c.lng, 45.0, 1e-9);
+
+    // Geodesic distance ≈ 790 km; the planar approximation reports ≈ 1112 km.
+    double geodesic = distance_between(pole, c);
+    EXPECT_NEAR(geodesic, geo::detail::deg2rad(90.0 - peak_lat) * geo::detail::kEarthRadius, 1e-6);
+    EXPECT_LT(geodesic, distance_to_segment(pole, a, b) - 300'000.0);
+}
+
+TEST(Poly, closest_point_on_segment_antimeridian) {
+    // Segment crossing the antimeridian — meaningless for the planar
+    // distance_to_segment, exact here: the foot keeps the longitude.
+    LatLng c = closest_point_on_segment(LatLng(5, 180), LatLng(0, 170), LatLng(0, -170));
+    EXPECT_NEAR_LatLng(LatLng(0, 180), c);
+    EXPECT_NEAR(distance_between(LatLng(5, 180), c),
+                geo::detail::deg2rad(5.0) * geo::detail::kEarthRadius, 1e-3);
+
+    // Both endpoints on one side, point on the other.
+    LatLng d = closest_point_on_segment(LatLng(0, -179), LatLng(10, 179), LatLng(-10, 179));
+    EXPECT_NEAR_LatLng(LatLng(0, 179), d);
+}
+
+TEST(Poly, closest_point_on_segment_brute_force) {
+    // Property test with a fixed seed: for random segments and points, the
+    // returned point must lie on the segment, and no densely sampled point
+    // of the arc may be meaningfully closer.
+    std::mt19937 rng(20260702u);
+    std::uniform_real_distribution<double> rand_lat(-90.0, 90.0);
+    std::uniform_real_distribution<double> rand_lng(-180.0, 180.0);
+    const int kSamples = 1000;
+
+    for (int trial = 0; trial < 150; ++trial) {
+        const LatLng a(rand_lat(rng), rand_lng(rng));
+        const LatLng b(rand_lat(rng), rand_lng(rng));
+        const LatLng p(rand_lat(rng), rand_lng(rng));
+        // Skip near-antipodal segments: the great circle is not unique and
+        // the nearer-endpoint convention would not match arc sampling.
+        if (geo::angle_between(a, b) > geo::detail::kPi - 1e-3) {
+            continue;
+        }
+
+        const LatLng c = closest_point_on_segment(p, a, b);
+        const double d = distance_between(p, c);
+
+        EXPECT_TRUE(geo::on_path(c, std::vector<LatLng>{a, b}, true, 1e-2))
+            << "trial " << trial << ": " << c << " not on " << a << " .. " << b;
+
+        double sampled = std::numeric_limits<double>::infinity();
+        for (int k = 0; k <= kSamples; ++k) {
+            sampled = std::min(sampled,
+                distance_between(p, geo::interpolate(a, b, static_cast<double>(k) / kSamples)));
+        }
+        EXPECT_LE(d, sampled + 1e-3)
+            << "trial " << trial << ": " << p << " -> " << c << " misses a closer arc point";
+    }
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -14,6 +14,8 @@
 #include "spherical/path_length.hpp"
 #include "spherical/signed_area.hpp"
 
+#include "poly/closest_point_on_path.hpp"
+#include "poly/closest_point_on_segment.hpp"
 #include "poly/contains.hpp"
 #include "poly/distance_to_segment.hpp"
 #include "poly/is_closed_polygon.hpp"


### PR DESCRIPTION
## What

Two new functions in `<geo/poly.hpp>` — the geodesically correct counterpart of `distance_to_segment`, which is documented to skew at high latitudes (no `cos(lat)` scaling) and to give meaningless results across the antimeridian:

- **`closest_point_on_segment(p, start, end)`** → the point of the minor great-circle arc closest to `p`;
- **`closest_point_on_path(point, path)`** → `std::optional<PathProjection>` = `{point, segment, distance}` — the "snap a GPS fix to the route" primitive.

`distance_to_segment` itself is untouched (android-maps-utils parity); its api.md note now points at the new functions.

## How

3D unit vectors: project the point onto the segment's great-circle plane, test arc containment with two triple-product signs, fall back to the nearer endpoint (by dot product) otherwise. No planar approximation — exact at any latitude and across the antimeridian.

Conventions, all documented: endpoint/vertex results return the original coordinates bit-exactly; equal endpoints yield `start`; antipodal endpoints (no unique great circle) yield the nearer endpoint — same spirit as `contains`' 180°-edge rule; ties at a shared path vertex go to the lower segment index; `result.distance == distance_between(point, result.point)` is an invariant.

## Showcase

Distance from the North Pole to the segment (80,0)–(80,90): the great circle bulges to lat ≈ 82.89°, so the true distance is **790 km**; planar `distance_to_segment` reports 1112 km. Segment (0,170)–(0,-170) with point (5,180): snapped to (0,180) exactly — the planar version calls this case "meaningless" in its own docs.

## Verification

- 60/60 tests, plain and under ASan/UBSan; `-Wall -Wextra -Wpedantic -Wconversion` clean.
- Scratch validation: 10 000 random (segment, point) triples against 4000-sample brute force over the arc — returned point always on the segment, worst disagreement **1.1e-8 m**; a seeded 150-trial property test is included in the suite.
- New tests cover: perpendicular foot, beyond-endpoint, degenerate/antipodal segments, pole-of-circle, high-latitude bulge (exact vertex-latitude formula), antimeridian crossing, path ties at shared vertices, empty/single-point paths, and the distance invariant.