### PR TITLE
1.2.0 feature set: polyline6, geodesic simplify, point_at_distance, LatLngBounds, normalized(), version.hpp, example, benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ if(GEO_UTILS_CPP_BUILD_TESTS)
     target_link_libraries(geo_utils_cpp_tests
         PRIVATE geo::utils GTest::GTest GTest::Main
     )
+    # Lets the suite assert that <geo/version.hpp> matches project(VERSION).
+    target_compile_definitions(geo_utils_cpp_tests PRIVATE
+        GEO_UTILS_CPP_TEST_CMAKE_VERSION="${PROJECT_VERSION}"
+    )
     gtest_discover_tests(geo_utils_cpp_tests)
 
     if(GEO_UTILS_CPP_ENABLE_COVERAGE)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Earth approximation model.
 
 - **Lat/lng-native API** — pass latitude/longitude coordinates directly, no
   framework-specific point types to convert through.
-- **Header-only, dependency-free** — about 40 KB across 6 headers; nothing
+- **Header-only, dependency-free** — about 50 KB across 8 headers; nothing
   to build or link.
 - **Spherical math** — distance, heading, offset, interpolation, area.
 - **Polygon utilities** — point-in-polygon, path proximity, snap-to-route

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Earth approximation model.
   (`closest_point_on_path`), Douglas–Peucker simplification, and
   `LatLngBounds` viewport math.
 - **Polyline encoding** — `encode`/`decode` for the Google Encoded Polyline
-  format.
+  format, including the polyline6 grid used by OSRM/Valhalla/Mapbox.
 - **Fast** — matches hand-written haversine on `distance`; especially strong
   on polygon `area` (see [benchmarks](docs/benchmarks.md)).
 - **Focused scope** — intentionally small API for GPS, navigation, tracking,

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Earth approximation model.
   to build or link.
 - **Spherical math** — distance, heading, offset, interpolation, area.
 - **Polygon utilities** — point-in-polygon, path proximity, snap-to-route
-  (`closest_point_on_path`), and Douglas–Peucker simplification.
+  (`closest_point_on_path`), Douglas–Peucker simplification, and
+  `LatLngBounds` viewport math.
 - **Polyline encoding** — `encode`/`decode` for the Google Encoded Polyline
   format.
 - **Fast** — matches hand-written haversine on `distance`; especially strong

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Earth approximation model.
 
 - **Lat/lng-native API** — pass latitude/longitude coordinates directly, no
   framework-specific point types to convert through.
-- **Header-only, dependency-free** — about 34 KB across 6 headers; nothing
+- **Header-only, dependency-free** — about 40 KB across 6 headers; nothing
   to build or link.
 - **Spherical math** — distance, heading, offset, interpolation, area.
-- **Polygon utilities** — point-in-polygon, path proximity, and
-  Douglas–Peucker simplification.
+- **Polygon utilities** — point-in-polygon, path proximity, snap-to-route
+  (`closest_point_on_path`), and Douglas–Peucker simplification.
 - **Polyline encoding** — `encode`/`decode` for the Google Encoded Polyline
   format.
 - **Fast** — matches hand-written haversine on `distance`; especially strong

--- a/benchmarks/speed/bench_geo_utils.cpp
+++ b/benchmarks/speed/bench_geo_utils.cpp
@@ -72,3 +72,61 @@ static void BM_GeoUtils_PathLength(benchmark::State& state) {
     state.SetItemsProcessed(state.iterations() * state.range(0));
 }
 BENCHMARK(BM_GeoUtils_PathLength)->Arg(10)->Arg(100)->Arg(1000)->Repetitions(5)->ReportAggregatesOnly(true);
+
+// --- closest_point_on_path (snap to route) -----------------------------------
+
+static void BM_GeoUtils_ClosestPointOnPath(benchmark::State& state) {
+    const auto route = geo::bench::bench_polygon(static_cast<std::size_t>(state.range(0)));
+    const auto queries = geo::bench::bench_queries();
+    for (auto _ : state) {
+        for (const auto& q : queries) {
+            benchmark::DoNotOptimize(geo::closest_point_on_path(q, route));
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(queries.size()));
+}
+BENCHMARK(BM_GeoUtils_ClosestPointOnPath)->Arg(10)->Arg(100)->Arg(1000)->Repetitions(5)->ReportAggregatesOnly(true);
+
+// --- point_at_distance --------------------------------------------------------
+
+static void BM_GeoUtils_PointAtDistance(benchmark::State& state) {
+    const auto route = geo::bench::bench_polygon(static_cast<std::size_t>(state.range(0)));
+    const double length = geo::path_length(route);
+    // A fixed spread of distances along the route, reused every iteration.
+    std::vector<double> distances;
+    distances.reserve(100);
+    for (int i = 0; i < 100; ++i) {
+        distances.push_back(length * i / 100.0);
+    }
+    for (auto _ : state) {
+        for (double d : distances) {
+            benchmark::DoNotOptimize(geo::point_at_distance(route, d));
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(distances.size()));
+}
+BENCHMARK(BM_GeoUtils_PointAtDistance)->Arg(10)->Arg(100)->Arg(1000)->Repetitions(5)->ReportAggregatesOnly(true);
+
+// --- simplify: planar (default) vs geodesic metric ---------------------------
+//
+// Random global points keep nearly every vertex at this tolerance, so the
+// Douglas-Peucker recursion does full work — a worst-case-shaped input that
+// is identical for both metrics.
+
+static void BM_GeoUtils_Simplify(benchmark::State& state) {
+    const auto route = geo::bench::random_points(static_cast<std::size_t>(state.range(0)));
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(geo::simplify(route, 1000.0));
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+BENCHMARK(BM_GeoUtils_Simplify)->Arg(100)->Arg(1000)->Repetitions(5)->ReportAggregatesOnly(true);
+
+static void BM_GeoUtils_SimplifyGeodesic(benchmark::State& state) {
+    const auto route = geo::bench::random_points(static_cast<std::size_t>(state.range(0)));
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(geo::simplify(route, 1000.0, /*geodesic=*/true));
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+BENCHMARK(BM_GeoUtils_SimplifyGeodesic)->Arg(100)->Arg(1000)->Repetitions(5)->ReportAggregatesOnly(true);

--- a/benchmarks/speed/bench_s2.cpp
+++ b/benchmarks/speed/bench_s2.cpp
@@ -104,3 +104,37 @@ static void BM_S2_PathLength(benchmark::State& state) {
     state.SetItemsProcessed(state.iterations() * state.range(0));
 }
 BENCHMARK(BM_S2_PathLength)->Arg(10)->Arg(100)->Arg(1000)->Repetitions(5)->ReportAggregatesOnly(true);
+
+// --- closest point on path: S2Polyline::Project ---------------------------
+//
+// Same algorithmic class as geo::closest_point_on_path — a linear scan over
+// the segments, no spatial index (that would be S2ClosestEdgeQuery over an
+// S2ShapeIndex, a different tool).
+
+static void BM_S2_ClosestPointOnPath(benchmark::State& state) {
+    const auto route_ll = geo::bench::bench_polygon(static_cast<std::size_t>(state.range(0)));
+    const S2Polyline line(to_s2_points(route_ll));
+    const auto queries = to_s2_points(geo::bench::bench_queries());
+    int next_vertex = 0;
+    for (auto _ : state) {
+        for (const auto& q : queries) {
+            benchmark::DoNotOptimize(line.Project(q, &next_vertex));
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(queries.size()));
+}
+BENCHMARK(BM_S2_ClosestPointOnPath)->Arg(10)->Arg(100)->Arg(1000)->Repetitions(5)->ReportAggregatesOnly(true);
+
+// --- point at distance: S2Polyline::Interpolate ----------------------------
+
+static void BM_S2_PointAtDistance(benchmark::State& state) {
+    const auto route_ll = geo::bench::bench_polygon(static_cast<std::size_t>(state.range(0)));
+    const S2Polyline line(to_s2_points(route_ll));
+    for (auto _ : state) {
+        for (int i = 0; i < 100; ++i) {
+            benchmark::DoNotOptimize(line.Interpolate(i / 100.0));
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * 100);
+}
+BENCHMARK(BM_S2_PointAtDistance)->Arg(10)->Arg(100)->Arg(1000)->Repetitions(5)->ReportAggregatesOnly(true);

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,7 +23,7 @@ are internal and not part of the supported API.
   an out-of-range `LatLng` gives unspecified (but memory-safe) results;
   see [LatLng § Validation](#validation). Container-taking functions
   (`area`, `path_length`, `point_at_distance`, `contains`, `on_edge`,
-  `on_path`, `closest_point_on_path`) are not
+  `on_path`, `closest_point_on_path`, `bounds`) are not
   marked `noexcept` because the generic `Path` contract doesn't
   constrain `operator[]` / `size()` to be `noexcept`; they don't throw
   themselves. `encode`, `decode`, and `simplify` return owning
@@ -31,8 +31,9 @@ are internal and not part of the supported API.
 - **Include strategy.** Each subsystem has its own header:
   `<geo/latlng.hpp>` (types), `<geo/spherical.hpp>` (distance, heading,
   area), `<geo/poly.hpp>` (point-in-polygon, on-path), `<geo/bounds.hpp>`
-  (bounding boxes), `<geo/encoding.hpp>` (encoded polylines). The umbrella
-  `<geo/geo.hpp>` pulls them all in for convenience.
+  (bounding boxes), `<geo/encoding.hpp>` (encoded polylines), plus
+  `<geo/version.hpp>` (version macros). The umbrella `<geo/geo.hpp>` pulls
+  them all in for convenience.
 
 ## LatLng
 
@@ -369,7 +370,9 @@ Utilities for computations involving polygons and polylines.
 > **Note on `geodesic` defaults.** `contains` defaults to rhumb-line
 > edges (cheaper, fine for polygons well inside one hemisphere);
 > `on_edge` and `on_path` default to great-circle edges (more accurate,
-> especially near the poles). Pass `geodesic` explicitly when in doubt.
+> especially near the poles); `simplify` defaults to the planar
+> `distance_to_segment` metric (upstream parity — see its entry). Pass
+> `geodesic` explicitly when in doubt.
 
 ### contains
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,8 +22,8 @@ are internal and not part of the supported API.
   and pathological inputs may yield NaN. Coordinates are never validated —
   an out-of-range `LatLng` gives unspecified (but memory-safe) results;
   see [LatLng § Validation](#validation). Container-taking functions
-  (`area`, `path_length`, `contains`, `on_edge`, `on_path`,
-  `closest_point_on_path`) are not
+  (`area`, `path_length`, `point_at_distance`, `contains`, `on_edge`,
+  `on_path`, `closest_point_on_path`) are not
   marked `noexcept` because the generic `Path` contract doesn't
   constrain `operator[]` / `size()` to be `noexcept`; they don't throw
   themselves. `encode`, `decode`, and `simplify` return owning
@@ -112,9 +112,9 @@ a.approx_equal(b, 1e-5);   // true (1e-5° ≈ 1 m on equator)
 
 A series of connected coordinates in an ordered sequence.
 
-`Path` is a template parameter accepted by `path_length`, `area`, `signed_area`,
-`contains`, `on_edge`, `on_path`, `closest_point_on_path`, `is_closed_polygon`,
-`simplify`, and `encode`.
+`Path` is a template parameter accepted by `path_length`, `point_at_distance`,
+`area`, `signed_area`, `contains`, `on_edge`, `on_path`,
+`closest_point_on_path`, `is_closed_polygon`, `simplify`, and `encode`.
 It must be a random-access container of `geo::LatLng` — specifically, it must
 support:
 
@@ -295,6 +295,26 @@ Returns: `double` — total length in meters; `0` for a path with fewer than 2 p
 ```cpp
 std::vector<geo::LatLng> path = { {0, 0}, {90, 0}, {0, 90} };
 std::cout << geo::path_length(path); // ~20,015 km (π·R, half Earth's circumference)
+```
+
+---
+
+### point_at_distance
+
+**`geo::point_at_distance(const Path& path, double distance)`** — Returns the point that lies `distance` meters along the path from its first vertex — "where is the vehicle after N meters of route". The natural companion of `path_length` and the snap-to-route functions.
+
+- `distance` — meters along the path, measured with the same formula as
+  `path_length`. Clamped to the path: values `<= 0` return the first vertex
+  and values `>= path_length(path)` return the last one, both with their
+  coordinates exactly as given.
+
+Returns: `std::optional<LatLng>` — the point, or `std::nullopt` for an empty path.
+
+```cpp
+std::vector<geo::LatLng> route = { {0, 0}, {0, 10}, {10, 10} };
+
+auto midpoint = geo::point_at_distance(route, geo::path_length(route) / 2);
+auto in_100km = geo::point_at_distance(route, 100'000.0); // {0, ~0.9}
 ```
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,14 +15,15 @@ are internal and not part of the supported API.
 - **Thread safety.** All functions are pure (no global mutable state, no
   caching) and safe to call concurrently from multiple threads.
 - **Error handling.** Scalar functions (`heading`, `offset`,
-  `interpolate`, `distance_between`, `distance_to_segment`) are
-  `noexcept`. Out-of-domain inputs are not asserted: `interpolate` with
+  `interpolate`, `distance_between`, `distance_to_segment`,
+  `closest_point_on_segment`) are `noexcept`. Out-of-domain inputs are not asserted: `interpolate` with
   `fraction` outside `[0, 1]` extrapolates along the great circle,
   `offset_origin` returns `std::nullopt` when no origin can be computed,
   and pathological inputs may yield NaN. Coordinates are never validated —
   an out-of-range `LatLng` gives unspecified (but memory-safe) results;
   see [LatLng § Validation](#validation). Container-taking functions
-  (`area`, `path_length`, `contains`, `on_edge`, `on_path`) are not
+  (`area`, `path_length`, `contains`, `on_edge`, `on_path`,
+  `closest_point_on_path`) are not
   marked `noexcept` because the generic `Path` contract doesn't
   constrain `operator[]` / `size()` to be `noexcept`; they don't throw
   themselves. `encode`, `decode`, and `simplify` return owning
@@ -99,7 +100,8 @@ a.approx_equal(b, 1e-5);   // true (1e-5° ≈ 1 m on equator)
 A series of connected coordinates in an ordered sequence.
 
 `Path` is a template parameter accepted by `path_length`, `area`, `signed_area`,
-`contains`, `on_edge`, `on_path`, `is_closed_polygon`, `simplify`, and `encode`.
+`contains`, `on_edge`, `on_path`, `closest_point_on_path`, `is_closed_polygon`,
+`simplify`, and `encode`.
 It must be a random-access container of `geo::LatLng` — specifically, it must
 support:
 
@@ -402,7 +404,9 @@ Returns: `double` — distance in meters, always ≥ 0.
 > percent at high latitudes (around `lat 80°`); and longitudes are used as-is,
 > so segments crossing the antimeridian (`±180°`) yield meaningless results —
 > a point lying exactly on such a segment can report kilometers of distance.
-> For tolerance checks against true geodesic segments, use `on_path`.
+> For tolerance checks against true geodesic segments, use `on_path`; for the
+> geodesically correct closest point and distance, use
+> `closest_point_on_segment` / `closest_point_on_path`.
 
 ```cpp
 geo::LatLng start{28.05359, -82.41632};
@@ -411,6 +415,71 @@ geo::LatLng point{28.05342, -82.41594};
 
 // Point lies ~38 m east-northeast of the segment
 std::cout << geo::distance_to_segment(point, start, end);
+```
+
+---
+
+### closest_point_on_segment
+
+**`geo::closest_point_on_segment(const LatLng& p, const LatLng& start, const LatLng& end)`** — Returns the point of the great-circle segment `[start, end]` closest to `p`.
+
+The geodesically correct counterpart of `distance_to_segment`: the segment is
+the minor great-circle arc between its endpoints, computed via 3D vector
+projection with no planar approximation — accurate at any latitude and across
+the antimeridian. The distance from `p` to the segment is
+`distance_between(p, closest_point_on_segment(p, start, end))`.
+
+Conventions:
+
+- When the closest point is a segment endpoint, that endpoint is returned
+  with its coordinates exactly as given.
+- Equal (`operator==`) endpoints yield `start`.
+- Antipodal endpoints do not define a unique great circle; the nearer
+  endpoint is returned (the same ambiguity `contains` resolves for
+  180°-spanning edges).
+
+Returns: `LatLng` — the closest point of the segment.
+
+```cpp
+geo::LatLng a{0, 0};
+geo::LatLng b{0, 90};
+
+geo::closest_point_on_segment({20, 30}, a, b);  // {0, 30} — perpendicular foot
+geo::closest_point_on_segment({10, -20}, a, b); // {0, 0}  — beyond start, endpoint returned
+
+// Across the antimeridian (meaningless for distance_to_segment):
+geo::closest_point_on_segment({5, 180}, {0, 170}, {0, -170}); // {0, 180}
+```
+
+---
+
+### closest_point_on_path
+
+**`geo::closest_point_on_path(const LatLng& point, const Path& path)`** — Projects the point onto the closest of the path's great-circle segments — "snap to route". Returns `std::nullopt` for an empty path.
+
+The result is a `geo::PathProjection`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `point` | `LatLng` | the closest point of the path |
+| `segment` | `std::size_t` | index `i`: the point lies on the segment `path[i]` → `path[i + 1]` (`0` for a single-point path) |
+| `distance` | `double` | great-circle distance to `point` in meters; always equals `distance_between(point, result.point)` |
+
+Segments are minor great-circle arcs, as in `on_path(geodesic = true)`. If
+several segments are equally close — typically when the closest point is a
+shared vertex — the lowest segment index wins, and vertex coordinates are
+returned exactly as given. Complexity is O(n) in the number of vertices.
+
+Returns: `std::optional<PathProjection>` — the projection, or `std::nullopt` for an empty path.
+
+```cpp
+std::vector<geo::LatLng> route = { {0, 0}, {0, 10}, {10, 10} };
+geo::LatLng gps{8.0, 9.5};  // a GPS fix near the second leg
+
+auto snapped = geo::closest_point_on_path(gps, route);
+// snapped->segment  == 1
+// snapped->point    ≈ {8.0, 10}
+// snapped->distance ≈ 55 km
 ```
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,6 +76,19 @@ still compares unequal to `LatLng(0, 0)`, and rhumb-line functions may
 produce NaN from it. Validate or normalize coordinates at the boundary of
 your system instead of relying on any of this behavior.
 
+To normalize, use `normalized()`: it clamps the latitude to `[-90, 90]` and
+wraps the longitude to `[-180, 180)` — the same conventions as the Android
+Maps SDK constructor. In-range values pass through bit-exactly (longitude
+`180` becomes `-180`); NaN components propagate, so garbage stays invalid
+rather than turning into a fake coordinate.
+
+```cpp
+geo::LatLng{40.7, -74.0}.normalized();  // unchanged
+geo::LatLng{0, 185}.normalized();       // {0, -175}
+geo::LatLng{91, 540}.normalized();      // {90, -180}
+geo::LatLng{NAN, 0}.normalized();       // {NaN, 0} — still !is_valid()
+```
+
 ### Equality
 
 `operator==` performs an **approximate** comparison with tolerance

--- a/docs/api.md
+++ b/docs/api.md
@@ -517,18 +517,24 @@ std::cout << geo::is_closed_polygon(poly); // true
 
 ### simplify
 
-**`geo::simplify(const Path& poly, double tolerance)`** — Simplifies the given polyline or polygon using the [Douglas–Peucker](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) decimation algorithm: keeps the vertices that lie farther than `tolerance` meters from the simplified shape, drops the rest. The first and last points are always kept, every returned point is one of the input points (in input order), and the input is not modified.
+**`geo::simplify(const Path& poly, double tolerance, bool geodesic = false)`** — Simplifies the given polyline or polygon using the [Douglas–Peucker](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) decimation algorithm: keeps the vertices that lie farther than `tolerance` meters from the simplified shape, drops the rest. The first and last points are always kept, every returned point is one of the input points (in input order), and the input is not modified.
 
 A closed polygon (in the `is_closed_polygon` sense) is simplified including its closing segment, so the result is a closed polygon too.
 
 - `tolerance` — maximum distance in meters a dropped vertex may lie from the simplified path; larger values drop more points.
+- `geodesic` — `false` (default) measures distances with `distance_to_segment`
+  (upstream PolyUtil behavior); `true` measures against true great-circle
+  segments via `closest_point_on_segment`.
 
 Returns: `std::vector<LatLng>` — the simplified path; empty only for an empty input.
 
-> **Note.** Distances are measured with `distance_to_segment`, so its
-> approximation limits apply — in particular for segments crossing the
-> antimeridian. Worst-case complexity is O(n²) in the number of input
-> points.
+> **Note.** With the default `geodesic = false` the `distance_to_segment`
+> approximation limits apply — in particular, polylines crossing the
+> antimeridian are mis-measured and barely simplify. Pass `geodesic = true`
+> for exact behavior at any latitude and across the antimeridian, at roughly
+> twice the cost per vertex; vertices near the tolerance threshold may
+> resolve differently between the two modes. Worst-case complexity is O(n²)
+> in the number of input points.
 
 ```cpp
 std::vector<geo::LatLng> route = {

--- a/docs/api.md
+++ b/docs/api.md
@@ -552,10 +552,10 @@ Returns: `std::vector<LatLng>` — the simplified path; empty only for an empty 
 > **Note.** With the default `geodesic = false` the `distance_to_segment`
 > approximation limits apply — in particular, polylines crossing the
 > antimeridian are mis-measured and barely simplify. Pass `geodesic = true`
-> for exact behavior at any latitude and across the antimeridian, at roughly
-> twice the cost per vertex; vertices near the tolerance threshold may
-> resolve differently between the two modes. Worst-case complexity is O(n²)
-> in the number of input points.
+> for exact behavior at any latitude and across the antimeridian, at two to
+> three times the cost per vertex (see [benchmarks.md](benchmarks.md));
+> vertices near the tolerance threshold may resolve differently between the
+> two modes. Worst-case complexity is O(n²) in the number of input points.
 
 ```cpp
 std::vector<geo::LatLng> route = {

--- a/docs/api.md
+++ b/docs/api.md
@@ -687,3 +687,22 @@ std::cout << path[0];     // LatLng(38.5, -120.2)
 | Symbol | Value | Description |
 |---|---|---|
 | `geo::kDefaultTolerance` | `0.1` | Default tolerance in meters for `on_edge` / `on_path` |
+
+## Version macros
+
+`<geo/version.hpp>` (also pulled in by the umbrella `<geo/geo.hpp>`) defines
+the library version for compile-time feature detection:
+
+| Macro | Example | Description |
+|---|---|---|
+| `GEO_UTILS_CPP_VERSION_MAJOR` / `_MINOR` / `_PATCH` | `1` / `1` / `0` | version components |
+| `GEO_UTILS_CPP_VERSION` | `10100` | `major·10000 + minor·100 + patch`, usable in `#if` |
+| `GEO_UTILS_CPP_VERSION_STRING` | `"1.1.0"` | dotted string |
+
+```cpp
+#include <geo/version.hpp>
+
+#if GEO_UTILS_CPP_VERSION >= 10200
+// use closest_point_on_path, LatLngBounds, ...
+#endif
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,9 +30,9 @@ are internal and not part of the supported API.
   containers and can throw `std::bad_alloc` on allocation failure.
 - **Include strategy.** Each subsystem has its own header:
   `<geo/latlng.hpp>` (types), `<geo/spherical.hpp>` (distance, heading,
-  area), `<geo/poly.hpp>` (point-in-polygon, on-path), `<geo/encoding.hpp>`
-  (encoded polylines). The umbrella `<geo/geo.hpp>` pulls all four in for
-  convenience.
+  area), `<geo/poly.hpp>` (point-in-polygon, on-path), `<geo/bounds.hpp>`
+  (bounding boxes), `<geo/encoding.hpp>` (encoded polylines). The umbrella
+  `<geo/geo.hpp>` pulls them all in for convenience.
 
 ## LatLng
 
@@ -114,7 +114,8 @@ A series of connected coordinates in an ordered sequence.
 
 `Path` is a template parameter accepted by `path_length`, `point_at_distance`,
 `area`, `signed_area`, `contains`, `on_edge`, `on_path`,
-`closest_point_on_path`, `is_closed_polygon`, `simplify`, and `encode`.
+`closest_point_on_path`, `is_closed_polygon`, `simplify`, `bounds`, and
+`encode`.
 It must be a random-access container of `geo::LatLng` — specifically, it must
 support:
 
@@ -565,6 +566,64 @@ std::vector<geo::LatLng> route = {
 auto simplified = geo::simplify(route, /*tolerance=*/88.0);
 std::cout << simplified.size(); // 4 — two vertices within 88 m are dropped
 ```
+
+---
+
+## Bounds
+
+A latitude/longitude aligned rectangle — viewport math and a cheap prefilter
+for the polygon functions.
+
+```cpp
+#include <geo/bounds.hpp>
+```
+
+### LatLngBounds
+
+**`geo::LatLngBounds{southwest, northeast}`** — a rectangle delimited by its south-west and north-east corners, in degrees.
+
+The longitude span runs **eastward** from `southwest.lng` to `northeast.lng`,
+so bounds may cross the antimeridian: `southwest.lng > northeast.lng`
+describes exactly that (sw lng `170`, ne lng `-170` covers `[170, 180] ∪
+[-180, -170]`). Equal longitudes describe a single meridian, not the whole
+circle. `southwest.lat <= northeast.lat` is expected; as everywhere in the
+library nothing is validated — use `is_valid()`.
+
+| Member | Meaning |
+|---|---|
+| `contains(point)` | whether the point is inside (boundaries inclusive; longitudes modulo 360, so `180` and `-180` are interchangeable) |
+| `extend(point)` | grow by the smallest amount that contains the point (Android builder semantics; east/west ties go east) |
+| `center()` | center of the bounds; the longitude midpoint follows the eastward span and is wrapped to `[-180, 180)` |
+| `intersects(other)` | whether the two bounds share at least one point (touching edges count) |
+| `lng_span()` | eastward longitude span in degrees, `[0, 360)` |
+| `is_valid()` | corners valid and latitudes ordered |
+| `operator==` | corner-wise approximate equality (`LatLng::operator==` semantics) |
+
+```cpp
+geo::LatLngBounds pacific{{-10, 170}, {10, -170}};  // crosses the antimeridian
+
+pacific.contains({0, 180});   // true
+pacific.contains({0, 0});     // false
+pacific.center();             // {0, 180}
+```
+
+---
+
+### bounds
+
+**`geo::bounds(const Path& path)`** — Returns the bounds of the path, built by extending point-by-point in input order (`extend` semantics). Returns `std::nullopt` for an empty path.
+
+A point outside `bounds(polygon)` is guaranteed to be outside the polygon,
+which makes the bounds a cheap prefilter in front of `contains` / `on_path`:
+
+```cpp
+std::vector<geo::LatLng> polygon = /* ... */;
+auto box = geo::bounds(polygon);
+
+bool inside = box->contains(p) && geo::contains(p, polygon);
+```
+
+Returns: `std::optional<LatLngBounds>`.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -553,21 +553,33 @@ used by the Google Maps APIs.
 
 ### encode
 
-**`geo::encode(const Path& path)`** — Encodes a sequence of LatLngs into an encoded path string. Coordinates are quantized to `1e-5` degrees (about one meter), so an encode/decode round-trip is lossy beyond that precision.
+**`geo::encode(const Path& path, unsigned precision = 5)`** — Encodes a sequence of LatLngs into an encoded path string. Coordinates are quantized to `10^-precision` degrees, so an encode/decode round-trip is lossy beyond that grid.
+
+- `precision` — decimal digits of the quantization grid. The default `5`
+  (about one meter) is the classic Google Maps encoding; `6` is the
+  **polyline6** variant used by OSRM, Valhalla, and Mapbox. Valid values are
+  `0` to `6`: at `6` every valid coordinate and every point-to-point delta
+  still fits `decode`'s 32-bit arithmetic (`7` round-trips only deltas under
+  ~107°, counting the first point's offset from `(0, 0)`; `8`+ overflows).
 
 Returns: `std::string` — the encoded polyline; empty for an empty path.
 
 ```cpp
 std::vector<geo::LatLng> path = { {38.5, -120.2}, {40.7, -120.95}, {43.252, -126.453} };
 
-std::cout << geo::encode(path); // "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+std::cout << geo::encode(path);    // "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+std::cout << geo::encode(path, 6); // "_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI" (polyline6)
 ```
 
 ---
 
 ### decode
 
-**`geo::decode(std::string_view encoded)`** — Decodes an encoded path string into a sequence of LatLngs on the `1e-5`-degree grid.
+**`geo::decode(std::string_view encoded, unsigned precision = 5)`** — Decodes an encoded path string into a sequence of LatLngs on the `10^-precision`-degree grid.
+
+- `precision` — must match the precision the string was encoded with: `5`
+  (default) for the classic Google Maps encoding, `6` for polyline6
+  (OSRM, Valhalla, Mapbox).
 
 Returns: `std::vector<LatLng>` — the decoded points; empty for an empty string.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -10,10 +10,11 @@ For build and run instructions see [`benchmarks/README.md`](../benchmarks/README
 ## TL;DR
 
 - **Speed.** Matches Boost.Geometry's spherical strategy and hand-written
-  haversine on `distance` / `heading`; wins on `area`; loses `contains`
-  and `path_length` to S2, which pays a hidden `lat/lng → S2Point`
-  conversion in real workloads. ~30× faster than GeographicLib's WGS84
-  geodesic — but on a sphere, less accurate.
+  haversine on `distance` / `heading`; wins on `area` and
+  `point_at_distance`; loses `contains`, `path_length`, and snap-to-route
+  to S2, which pays a hidden `lat/lng → S2Point` conversion in real
+  workloads. ~30× faster than GeographicLib's WGS84 geodesic — but on a
+  sphere, less accurate.
 - **Deployment footprint.** Header-only, zero deps — nothing to add to
   your build's dependency tree, and no `.so`/`.dylib` to ship alongside
   the binary.
@@ -167,6 +168,54 @@ S2 wins on `path_length` algorithmically (~2×) — once the input is
 Boost.Geometry within noise. GeographicLib pays the ellipsoidal cost.
 Note: a lat/lng-input workload would push the S2 column down by the
 per-call conversion cost, which is not counted here.
+
+### `closest_point_on_path` (snap to route, M queries/s)
+
+1 000 query points per iteration; route of N vertices. The comparable is
+`S2Polyline::Project` — the same algorithmic class (a linear scan over the
+segments, no spatial index; the indexed tool would be `S2ClosestEdgeQuery`,
+a different trade-off).
+
+| Library                     |  N=10    | N=100     | N=1 000   |
+| --------------------------- | -------: | --------: | --------: |
+| **geo-utils-cpp**           |     1.53 |     0.189 |     0.021 |
+| S2 (`S2Polyline::Project`)  | **4.41** | **0.708** | **0.076** |
+
+Both sides walk every segment; S2's polyline is pre-built as unit vectors
+while our lat/lng-native API converts each vertex per call — that
+conversion is essentially the whole ~3× gap, the same asymmetry noted for
+`path_length` above. For a lat/lng-input workload the columns converge.
+
+### `point_at_distance` (M queries/s)
+
+100 distances spread along a route of N vertices, per iteration. The
+comparable is `S2Polyline::Interpolate`.
+
+| Library                        |  N=10    | N=100    | N=1 000   |
+| ------------------------------ | -------: | -------: | --------: |
+| **geo-utils-cpp**              | **4.21** | **0.79** | **0.096** |
+| S2 (`S2Polyline::Interpolate`) |     3.88 |     0.50 |     0.051 |
+
+We win ~1.6–1.9× at larger N despite the per-vertex lat/lng conversion:
+`point_at_distance` walks segments until the target distance and stops,
+while `S2Polyline::Interpolate` normalizes by the full polyline length on
+every call.
+
+### `simplify`: planar vs geodesic metric (M input vertices/s)
+
+geo-utils-cpp only — the cost of the `geodesic = true` mode added for
+antimeridian/high-latitude correctness, on a worst-case random input
+(tolerance 1 km, nearly every vertex kept).
+
+| Metric                  | N=100    | N=1 000  |
+| ----------------------- | -------: | -------: |
+| planar (default)        |     3.00 |     1.74 |
+| `geodesic = true`       |     2.31 |     0.68 |
+
+The geodesic metric costs ~1.3× at N=100 and ~2.6× at N=1 000 — the
+3D-projection distance is doing real extra work per vertex. Reach for it
+when the polyline can cross the antimeridian or sits at high latitudes;
+the default stays bit-compatible with upstream PolyUtil.
 
 ## Deployment footprint
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,9 +103,8 @@ conan install --requires=geo-utils-cpp/1.1.0 --build=missing
 
 Conan Center support is pending
 [conan-io/conan-center-index#30152](https://github.com/conan-io/conan-center-index/pull/30152);
-until that lands, install from the local recipe in the
-[conan/](https://github.com/gistrec/geo-utils-cpp/tree/master/conan)
-directory.
+until that lands, the `conan install` line above requires the recipe from
+that PR (or use one of the other installation methods).
 
 ### System install
 
@@ -146,7 +145,10 @@ for tighter compile times:
 // Or individual modules
 #include <geo/latlng.hpp>     // types
 #include <geo/spherical.hpp>  // distance, heading, offset, area
-#include <geo/poly.hpp>       // point-in-polygon, on-path
+#include <geo/poly.hpp>       // point-in-polygon, on-path, snap-to-route
+#include <geo/bounds.hpp>     // LatLngBounds
+#include <geo/encoding.hpp>   // encoded polylines
+#include <geo/version.hpp>    // version macros
 ```
 
 ### Example: distance and heading between two points
@@ -171,7 +173,7 @@ int main() {
 ### Example: round-trip with custom tolerance
 
 `LatLng::operator==` is an approximate comparison with tolerance `1e-12`
-degrees (≈ 0.1 nanometers on Earth) — fine for bit-exact equality, too
+degrees (≈ 0.1 micrometers on Earth) — fine for bit-exact equality, too
 strict to compare results of floating-point geometry. For coarser-scale
 comparisons, pass an explicit tolerance to `approx_equal`:
 
@@ -242,6 +244,8 @@ ctest --test-dir build-cmake --output-on-failure
 | --------------------------------- | ------------------------ | ------- |
 | `GEO_UTILS_CPP_BUILD_TESTS`       | `ON` if top-level        | Build unit tests |
 | `GEO_UTILS_CPP_BUILD_EXAMPLES`    | `ON` if top-level        | Build the examples in [`examples/`](../examples/) |
+| `GEO_UTILS_CPP_BUILD_BENCHMARKS`  | `OFF`                    | Build the [benchmarks](benchmarks.md) (fetches Google Benchmark) |
+| `GEO_UTILS_CPP_BUILD_FUZZERS`     | `OFF`                    | Build the libFuzzer targets in `tests/fuzz/`; Clang only |
 | `GEO_UTILS_CPP_ENABLE_COVERAGE`   | `OFF`                    | gcov instrumentation; GCC/Clang only |
 
 Downstream users consuming `geo-utils-cpp` as a dependency don't need to

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach(example spherical poly)
+foreach(example spherical poly gps_track)
     add_executable(example_${example} ${example}.cpp)
     target_link_libraries(example_${example} PRIVATE geo::utils)
     if(GEO_UTILS_CPP_BUILD_TESTS)

--- a/examples/gps_track.cpp
+++ b/examples/gps_track.cpp
@@ -1,0 +1,63 @@
+// An end-to-end GPS-track pipeline: decode an encoded polyline, inspect its
+// bounds, simplify it, snap a live GPS fix to the route, and predict a
+// position N meters down the road.
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include <geo/geo.hpp>
+
+int main() {
+    // A 95-point GPS track as it would arrive from a routing API (the
+    // Encoded Polyline format, 1e-5-degree grid).
+    static const char kTrack[] =
+        "elfjD~a}uNOnFN~Em@fJv@tEMhGDjDe@hG^nF??@lA?n@IvAC`Ay@A{@DwCA{CF_EC{CEi@PBTFDJBJ?V?n@?D@?A@?@?F?F?"
+        "LAf@?n@@`@@T@~@FpA?fA?p@?r@?vAH`@OR@^ETFJCLD?JA^?J?P?fAC`B@d@?b@A\\@`@Ad@@\\?`@?f@?V?H?DD@DDBBDBD?"
+        "D?B?B@B@@@B@B@B@D?D?JAF@H@FCLADBDBDCFAN?b@Af@@x@@";
+    std::vector<geo::LatLng> track = geo::decode(kTrack);
+    std::cout << "Decoded " << track.size() << " points\n";
+    assert(track.size() == 95);
+
+    // Where does the track live? LatLngBounds is a cheap prefilter: a point
+    // outside the bounds cannot be on the track.
+    auto box = geo::bounds(track);
+    assert(box.has_value());
+    std::cout << "Bounds: " << *box << ", center " << box->center() << "\n";
+    assert(box->contains(track.front()) && box->contains(track.back()));
+
+    double full_length = geo::path_length(track);
+    std::cout << "Track length: " << full_length << " m\n";
+
+    // Simplify for storage or display. geodesic=true measures true
+    // great-circle distances (exact at any latitude and across the
+    // antimeridian); 5 m tolerance keeps the shape within GPS noise.
+    std::vector<geo::LatLng> simplified = geo::simplify(track, 5.0, /*geodesic=*/true);
+    std::cout << "Simplified to " << simplified.size() << " points ("
+              << geo::path_length(simplified) << " m)\n";
+    assert(simplified.size() < track.size());
+    assert(std::abs(geo::path_length(simplified) - full_length) < full_length * 0.05);
+
+    // A GPS fix comes in: snap it to the route.
+    geo::LatLng fix(track[40].lat + 0.00012, track[40].lng - 0.00008);  // ~15 m off the road
+    auto snapped = geo::closest_point_on_path(fix, simplified);
+    assert(snapped.has_value());
+    std::cout << "GPS fix " << fix << " snapped to " << snapped->point
+              << " (segment " << snapped->segment << ", " << snapped->distance << " m off)\n";
+    assert(snapped->distance < 25.0);
+    assert(geo::on_path(snapped->point, simplified, /*geodesic=*/true, /*tolerance=*/0.01));
+
+    // Predict the position 500 m down the road from the start.
+    auto eta_point = geo::point_at_distance(simplified, 500.0);
+    assert(eta_point.has_value());
+    std::cout << "500 m into the route: " << *eta_point << "\n";
+    assert(box->contains(*eta_point));
+
+    // Ship the simplified track onward as polyline6 (the OSRM/Valhalla grid).
+    std::string reencoded = geo::encode(simplified, 6);
+    std::cout << "Re-encoded (polyline6, " << reencoded.size() << " chars)\n";
+    assert(geo::decode(reencoded, 6).size() == simplified.size());
+
+    return 0;
+}

--- a/include/geo/bounds.hpp
+++ b/include/geo/bounds.hpp
@@ -1,0 +1,153 @@
+// Copyright 2026 Aleksandr Kovalko
+// Licensed under the Apache License, Version 2.0
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <ostream>
+
+#include "detail/math.hpp"
+#include "latlng.hpp"
+
+namespace geo {
+
+/**
+ * A latitude/longitude aligned rectangle, delimited by its south-west and
+ * north-east corners (degrees).
+ *
+ * The longitude span runs EASTWARD from southwest.lng to northeast.lng, so
+ * bounds may cross the antimeridian: southwest.lng > northeast.lng describes
+ * exactly that (e.g. sw lng 170, ne lng -170 covers lng in [170, 180] and
+ * [-180, -170]). Equal longitudes describe a single meridian, not the whole
+ * circle. As an eastern limit prefer +180 and as a western one -180 — the
+ * two spellings denote the same meridian but produce different spans.
+ *
+ * southwest.lat <= northeast.lat is expected. As everywhere in the library,
+ * nothing is validated — use is_valid() for untrusted input.
+ */
+struct LatLngBounds {
+    LatLng southwest;
+    LatLng northeast;
+
+    constexpr LatLngBounds(const LatLng& sw, const LatLng& ne) noexcept
+        : southwest(sw), northeast(ne) {}
+
+    /**
+     * Returns whether both corners are valid coordinates and the latitudes
+     * are ordered (southwest.lat <= northeast.lat).
+     */
+    [[nodiscard]] constexpr bool is_valid() const noexcept {
+        return southwest.is_valid() && northeast.is_valid() &&
+               southwest.lat <= northeast.lat;
+    }
+
+    /**
+     * Eastward longitude span in degrees, in [0, 360).
+     */
+    [[nodiscard]] double lng_span() const noexcept {
+        return detail::mod(northeast.lng - southwest.lng, 360.0);
+    }
+
+    /**
+     * Returns whether the point lies inside the bounds (boundaries
+     * inclusive). Longitudes are compared modulo 360, so 180 and -180 are
+     * interchangeable here.
+     */
+    [[nodiscard]] bool contains(const LatLng& point) const noexcept {
+        if (point.lat < southwest.lat || point.lat > northeast.lat) {
+            return false;
+        }
+        return detail::mod(point.lng - southwest.lng, 360.0) <= lng_span();
+    }
+
+    /**
+     * Grows the bounds by the smallest amount that makes them contain the
+     * point — the same incremental semantics as the Android LatLngBounds
+     * builder. Longitude ties (the point is equally far east and west) are
+     * resolved eastward. Note that the result depends on the order points
+     * are added in; for many points hopping more than 180 degrees apart the
+     * accumulated span may not be the minimal one.
+     */
+    void extend(const LatLng& point) noexcept {
+        if (point.lat < southwest.lat) {
+            southwest.lat = point.lat;
+        }
+        if (point.lat > northeast.lat) {
+            northeast.lat = point.lat;
+        }
+        if (detail::mod(point.lng - southwest.lng, 360.0) <= lng_span()) {
+            return;  // already inside longitude-wise
+        }
+        const double east = detail::mod(point.lng - northeast.lng, 360.0);
+        const double west = detail::mod(southwest.lng - point.lng, 360.0);
+        if (east <= west) {
+            // Extending east to the meridian 180 == -180: keep the +180
+            // spelling, otherwise the eastward span would jump by 360.
+            northeast.lng = point.lng == -180.0 ? 180.0 : point.lng;
+        } else {
+            southwest.lng = point.lng == 180.0 ? -180.0 : point.lng;
+        }
+    }
+
+    /**
+     * Returns the center of the bounds. The longitude midpoint follows the
+     * eastward span (antimeridian-aware) and is wrapped to [-180, 180).
+     */
+    [[nodiscard]] LatLng center() const noexcept {
+        return LatLng((southwest.lat + northeast.lat) / 2.0,
+                      detail::wrap(southwest.lng + lng_span() / 2.0, -180.0, 180.0));
+    }
+
+    /**
+     * Returns whether the two bounds share at least one point (touching
+     * edges count as intersecting).
+     */
+    [[nodiscard]] bool intersects(const LatLngBounds& other) const noexcept {
+        if (other.northeast.lat < southwest.lat || other.southwest.lat > northeast.lat) {
+            return false;
+        }
+        // Two eastward arcs on a circle overlap iff either arc's western
+        // edge lies within the other arc.
+        return detail::mod(other.southwest.lng - southwest.lng, 360.0) <= lng_span() ||
+               detail::mod(southwest.lng - other.southwest.lng, 360.0) <= other.lng_span();
+    }
+
+    /**
+     * Corner-wise approximate equality — LatLng::operator== semantics,
+     * including longitudes compared modulo 360.
+     */
+    [[nodiscard]] bool operator==(const LatLngBounds& other) const noexcept {
+        return southwest == other.southwest && northeast == other.northeast;
+    }
+
+    [[nodiscard]] bool operator!=(const LatLngBounds& other) const noexcept {
+        return !(*this == other);
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const LatLngBounds& b) {
+        return os << "LatLngBounds(" << b.southwest << ", " << b.northeast << ")";
+    }
+};
+
+/**
+ * Returns the bounds of the path, built by extending point-by-point in input
+ * order (LatLngBounds::extend semantics). Returns std::nullopt for an empty
+ * path. Useful as a cheap prefilter in front of contains() / on_path():
+ * a point outside bounds(polygon) is guaranteed to be outside the polygon.
+ */
+template <typename Path>
+[[nodiscard]] std::optional<LatLngBounds> bounds(const Path& path) {
+    const std::size_t size = path.size();
+    if (size == 0U) {
+        return std::nullopt;
+    }
+    const LatLng first(path[0].lat, path[0].lng);
+    LatLngBounds out(first, first);
+    for (std::size_t i = 1; i < size; ++i) {
+        out.extend(LatLng(path[i].lat, path[i].lng));
+    }
+    return out;
+}
+
+}  // namespace geo

--- a/include/geo/encoding.hpp
+++ b/include/geo/encoding.hpp
@@ -26,6 +26,15 @@ namespace geo {
 
 namespace detail {
 
+// Returns 10^digits as a double; exact for digits <= 15.
+[[nodiscard]] inline double pow10(unsigned digits) noexcept {
+    double factor = 1.0;
+    while (digits-- > 0U) {
+        factor *= 10.0;
+    }
+    return factor;
+}
+
 inline void encode_value(std::int64_t v, std::string& out) {
     // Zig-zag encode in unsigned arithmetic: left-shifting a negative signed
     // value is undefined behavior in C++17.
@@ -44,18 +53,25 @@ inline void encode_value(std::int64_t v, std::string& out) {
 
 /**
  * Encodes a sequence of LatLngs into a string using the Encoded Polyline
- * Algorithm Format. Coordinates are quantized to 1e-5 degrees (about one
- * meter), so an encode/decode round-trip is lossy beyond that precision.
+ * Algorithm Format. Coordinates are quantized to 10^-precision degrees, so
+ * an encode/decode round-trip is lossy beyond that grid. The default
+ * precision 5 (about one meter) is the classic Google Maps grid; pass 6 for
+ * the polyline6 variant used by OSRM, Valhalla, and Mapbox. Valid precisions
+ * are 0 to 6: at 6 every valid coordinate and every point-to-point delta
+ * still fits decode()'s 32-bit arithmetic. Precision 7 round-trips only
+ * deltas under ~107° (including the first point, whose deltas are taken
+ * from (0, 0)); 8+ overflows outright.
  */
 template <typename Path>
-[[nodiscard]] std::string encode(const Path& path) {
+[[nodiscard]] std::string encode(const Path& path, unsigned precision = 5U) {
+    const double factor = detail::pow10(precision);
     std::int64_t last_lat = 0;
     std::int64_t last_lng = 0;
     std::string result;
 
     for (const auto& point : path) {
-        std::int64_t lat = std::llround(point.lat * 1e5);
-        std::int64_t lng = std::llround(point.lng * 1e5);
+        std::int64_t lat = std::llround(point.lat * factor);
+        std::int64_t lng = std::llround(point.lng * factor);
 
         detail::encode_value(lat - last_lat, result);
         detail::encode_value(lng - last_lng, result);
@@ -68,14 +84,17 @@ template <typename Path>
 
 /**
  * Decodes an Encoded Polyline Algorithm Format string into a sequence of
- * LatLngs on the 1e-5-degree grid the format uses.
+ * LatLngs on the 10^-precision-degree grid: 5 (the default) for the classic
+ * Google Maps encoding, 6 for the polyline6 variant used by OSRM, Valhalla,
+ * and Mapbox. The precision must match the one the string was encoded with.
  *
  * The input is assumed to be a well-formed encoded polyline. Decoding any
  * string is memory-safe, but malformed input yields unspecified coordinates;
  * a string truncated mid-point yields the points decoded so far and drops
  * the incomplete trailing point.
  */
-[[nodiscard]] inline std::vector<LatLng> decode(std::string_view encoded) {
+[[nodiscard]] inline std::vector<LatLng> decode(std::string_view encoded, unsigned precision = 5U) {
+    const double factor = detail::pow10(precision);
     std::vector<LatLng> path;
     std::size_t index = 0;
     std::int32_t lat = 0;
@@ -115,7 +134,7 @@ template <typename Path>
         if (!decode_delta(lat) || !decode_delta(lng)) {
             break;
         }
-        path.push_back(LatLng(lat * 1e-5, lng * 1e-5));
+        path.push_back(LatLng(lat / factor, lng / factor));
     }
     return path;
 }

--- a/include/geo/geo.hpp
+++ b/include/geo/geo.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "bounds.hpp"
 #include "encoding.hpp"
 #include "latlng.hpp"
 #include "poly.hpp"

--- a/include/geo/geo.hpp
+++ b/include/geo/geo.hpp
@@ -8,3 +8,4 @@
 #include "latlng.hpp"
 #include "poly.hpp"
 #include "spherical.hpp"
+#include "version.hpp"

--- a/include/geo/latlng.hpp
+++ b/include/geo/latlng.hpp
@@ -60,6 +60,27 @@ struct LatLng {
     }
 
     /**
+     * Returns a copy with the latitude clamped to [-90, 90] and the
+     * longitude wrapped to [-180, 180) — the same conventions the Android
+     * Maps SDK constructor applies, and the same longitude range offset()
+     * and offset_origin() already return. In-range values pass through
+     * bit-exactly (longitude 180 wraps to -180). NaN components propagate;
+     * an infinite longitude yields NaN — the result stays not is_valid().
+     */
+    [[nodiscard]] LatLng normalized() const noexcept {
+        double norm_lat = lat < -90.0 ? -90.0 : (lat > 90.0 ? 90.0 : lat);
+        double norm_lng = lng;
+        if (!(lng >= -180.0 && lng < 180.0)) {
+            norm_lng = std::fmod(lng + 180.0, 360.0);
+            if (norm_lng < 0.0) {
+                norm_lng += 360.0;
+            }
+            norm_lng -= 180.0;
+        }
+        return LatLng(norm_lat, norm_lng);
+    }
+
+    /**
      * Approximate equality with a custom tolerance (in degrees, applied to both
      * latitude and longitude). Longitudes are compared modulo 360 so that 180°
      * and -180° are treated as equal (same meridian).

--- a/include/geo/poly.hpp
+++ b/include/geo/poly.hpp
@@ -16,6 +16,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <limits>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -119,6 +121,77 @@ namespace detail {
     double hav_along_track23 = (hav_dist23 - hav_cross_track) / cos_cross_track;
     double sin_sum_along_track = sin_sum_from_hav(hav_along_track13, hav_along_track23);
     return sin_sum_along_track > 0;
+}
+
+// A direction on the unit sphere in Cartesian coordinates.
+struct Vec3 {
+    double x;
+    double y;
+    double z;
+};
+
+[[nodiscard]] inline Vec3 to_unit_vec(const LatLng& point) noexcept {
+    double lat = deg2rad(point.lat);
+    double lng = deg2rad(point.lng);
+    double cos_lat = std::cos(lat);
+    return {cos_lat * std::cos(lng), cos_lat * std::sin(lng), std::sin(lat)};
+}
+
+// Scale-invariant: v does not have to be normalized.
+[[nodiscard]] inline LatLng vec_to_latlng(const Vec3& v) noexcept {
+    return LatLng(rad2deg(std::atan2(v.z, std::sqrt(v.x * v.x + v.y * v.y))),
+                  rad2deg(std::atan2(v.y, v.x)));
+}
+
+[[nodiscard]] inline Vec3 cross(const Vec3& u, const Vec3& v) noexcept {
+    return {u.y * v.z - u.z * v.y,
+            u.z * v.x - u.x * v.z,
+            u.x * v.y - u.y * v.x};
+}
+
+[[nodiscard]] inline double dot(const Vec3& u, const Vec3& v) noexcept {
+    return u.x * v.x + u.y * v.y + u.z * v.z;
+}
+
+// Angle between two directions, in radians. Scale-invariant and, unlike an
+// acos of the dot product, stable for both small and near-pi angles.
+[[nodiscard]] inline double vec_angle(const Vec3& u, const Vec3& v) noexcept {
+    Vec3 c = cross(u, v);
+    return std::atan2(std::sqrt(dot(c, c)), dot(u, v));
+}
+
+// Which point of the minor great-circle arc a->b is closest to p: the
+// perpendicular projection of p onto the arc's great circle (written to proj,
+// not normalized), or one of the endpoints. All inputs are unit vectors.
+enum class ArcNearest { kProjection, kStart, kEnd };
+
+[[nodiscard]] inline ArcNearest nearest_on_arc(const Vec3& a, const Vec3& b, const Vec3& p, Vec3& proj) noexcept {
+    // The nearer endpoint (larger dot product == smaller angle) is also the
+    // endpoint nearer to the projection along the circle, so it doubles as
+    // the answer whenever the projection falls outside the arc.
+    const Vec3 n = cross(a, b);
+    const double n2 = dot(n, n);
+    // n2 == sin^2(arc length). Degenerate arcs — endpoints closer than
+    // ~1e-12 rad or that close to antipodal — have no usable great-circle
+    // normal: for identical endpoints the arc is a point, for antipodal ones
+    // the connecting great circle is not unique (same ambiguity contains()
+    // resolves for 180-degree edges by convention). Use the nearer endpoint.
+    if (n2 <= 1e-24) {
+        return dot(p, a) >= dot(p, b) ? ArcNearest::kStart : ArcNearest::kEnd;
+    }
+    const double k = dot(p, n) / n2;
+    proj = {p.x - k * n.x, p.y - k * n.y, p.z - k * n.z};
+    // p at a pole of the great circle: the whole circle is 90 degrees away,
+    // so the nearer endpoint is as close as any point of the arc.
+    if (dot(proj, proj) <= 1e-24) {
+        return dot(p, a) >= dot(p, b) ? ArcNearest::kStart : ArcNearest::kEnd;
+    }
+    // proj lies within the minor arc iff it is on b's side of the plane
+    // spanned by a and n, and on a's side of the plane spanned by b and n.
+    if (dot(cross(a, proj), n) >= 0 && dot(cross(proj, b), n) >= 0) {
+        return ArcNearest::kProjection;
+    }
+    return dot(p, a) >= dot(p, b) ? ArcNearest::kStart : ArcNearest::kEnd;
 }
 
 // Computes whether a given point lies on or near a polyline within a tolerance.
@@ -281,6 +354,107 @@ template <typename Path>
     }
     LatLng su(start.lat + u * (end.lat - start.lat), start.lng + u * (end.lng - start.lng));
     return distance_between(p, su);
+}
+
+/**
+ * Returns the point of the great-circle segment [start, end] closest to p.
+ *
+ * The geodesically correct counterpart of distance_to_segment: the segment is
+ * the minor great-circle arc between its endpoints, with no planar
+ * approximation — accurate at any latitude and across the antimeridian. The
+ * distance from p to the segment is distance_between(p, closest_point_on_segment(...)).
+ *
+ * Conventions: when the closest point is a segment endpoint, that endpoint is
+ * returned with its coordinates exactly as given. Equal (operator==)
+ * endpoints yield start. Antipodal endpoints do not define a unique great
+ * circle — the nearer endpoint is returned.
+ */
+[[nodiscard]] inline LatLng closest_point_on_segment(const LatLng& p, const LatLng& start, const LatLng& end) noexcept {
+    if (start == end) {
+        return start;
+    }
+    detail::Vec3 proj{0.0, 0.0, 0.0};
+    const detail::ArcNearest nearest = detail::nearest_on_arc(
+        detail::to_unit_vec(start), detail::to_unit_vec(end), detail::to_unit_vec(p), proj);
+    if (nearest == detail::ArcNearest::kStart) {
+        return start;
+    }
+    if (nearest == detail::ArcNearest::kEnd) {
+        return end;
+    }
+    return detail::vec_to_latlng(proj);
+}
+
+/**
+ * The result of projecting a point onto a path: the closest point, the index
+ * of the segment it lies on (from path[segment] to path[segment + 1]; 0 for
+ * a single-point path), and the great-circle distance to it in meters —
+ * always equal to distance_between(point, result.point).
+ */
+struct PathProjection {
+    LatLng point;
+    std::size_t segment;
+    double distance;
+};
+
+/**
+ * Projects the point onto the closest of the path's great-circle segments
+ * ("snap to route"). Segments are minor great-circle arcs, as in
+ * on_path(geodesic = true), and the result is geodesically correct at any
+ * latitude and across the antimeridian — unlike distance_to_segment.
+ *
+ * Returns std::nullopt for an empty path. When several segments are equally
+ * close — typically when the closest point is a shared vertex — the lowest
+ * segment index wins. O(n) in the number of vertices.
+ */
+template <typename Path>
+[[nodiscard]] std::optional<PathProjection> closest_point_on_path(const LatLng& point, const Path& path) {
+    const std::size_t size = path.size();
+    if (size == 0) {
+        return std::nullopt;
+    }
+    const LatLng first(path[0].lat, path[0].lng);
+    if (size == 1) {
+        return PathProjection{first, 0, distance_between(point, first)};
+    }
+
+    // Vertices are converted once and shared between adjacent segments, so
+    // equally-close candidates at a shared vertex compare bit-identically and
+    // the strict < keeps the earliest segment.
+    const detail::Vec3 p = detail::to_unit_vec(point);
+    detail::Vec3 prev = detail::to_unit_vec(first);
+
+    double best_angle = std::numeric_limits<double>::infinity();
+    std::size_t best_segment = 0;
+    detail::ArcNearest best_nearest = detail::ArcNearest::kStart;
+    detail::Vec3 best_proj{0.0, 0.0, 0.0};
+
+    for (std::size_t i = 1; i < size; ++i) {
+        const detail::Vec3 cur = detail::to_unit_vec(LatLng(path[i].lat, path[i].lng));
+        detail::Vec3 proj{0.0, 0.0, 0.0};
+        const detail::ArcNearest nearest = detail::nearest_on_arc(prev, cur, p, proj);
+        const detail::Vec3& candidate =
+            nearest == detail::ArcNearest::kProjection ? proj
+            : nearest == detail::ArcNearest::kStart    ? prev
+                                                       : cur;
+        const double angle = detail::vec_angle(p, candidate);
+        if (angle < best_angle) {
+            best_angle = angle;
+            best_segment = i - 1;
+            best_nearest = nearest;
+            best_proj = proj;
+        }
+        prev = cur;
+    }
+
+    // Endpoint results reuse the original vertex coordinates exactly.
+    const LatLng best_point =
+        best_nearest == detail::ArcNearest::kStart
+            ? LatLng(path[best_segment].lat, path[best_segment].lng)
+        : best_nearest == detail::ArcNearest::kEnd
+            ? LatLng(path[best_segment + 1].lat, path[best_segment + 1].lng)
+            : detail::vec_to_latlng(best_proj);
+    return PathProjection{best_point, best_segment, distance_between(point, best_point)};
 }
 
 /**

--- a/include/geo/poly.hpp
+++ b/include/geo/poly.hpp
@@ -486,8 +486,8 @@ template <typename Path>
  * particular for segments crossing the antimeridian. Pass geodesic = true
  * to measure against true great-circle segments via
  * closest_point_on_segment: exact at any latitude and across the
- * antimeridian, at roughly twice the cost per vertex. Results of the two
- * modes can differ for vertices near the tolerance threshold.
+ * antimeridian, at two to three times the cost per vertex. Results of the
+ * two modes can differ for vertices near the tolerance threshold.
  * Worst-case complexity is O(n^2).
  */
 template <typename Path>

--- a/include/geo/poly.hpp
+++ b/include/geo/poly.hpp
@@ -481,12 +481,17 @@ template <typename Path>
  * points. A closed polygon (is_closed_polygon) is simplified including its
  * closing segment.
  *
- * Distances are measured with distance_to_segment, so its approximation
- * limits apply — in particular for segments crossing the antimeridian.
+ * By default distances are measured with distance_to_segment (upstream
+ * PolyUtil behavior), so its planar-approximation limits apply — in
+ * particular for segments crossing the antimeridian. Pass geodesic = true
+ * to measure against true great-circle segments via
+ * closest_point_on_segment: exact at any latitude and across the
+ * antimeridian, at roughly twice the cost per vertex. Results of the two
+ * modes can differ for vertices near the tolerance threshold.
  * Worst-case complexity is O(n^2).
  */
 template <typename Path>
-[[nodiscard]] std::vector<LatLng> simplify(const Path& poly, double tolerance) {
+[[nodiscard]] std::vector<LatLng> simplify(const Path& poly, double tolerance, bool geodesic = false) {
     std::size_t n = poly.size();
     if (n == 0) {
         return {};
@@ -520,7 +525,10 @@ template <typename Path>
             double max_dist = 0;
             std::size_t max_idx = 0;
             for (std::size_t i = start + 1; i < end; ++i) {
-                double dist = distance_to_segment(working[i], working[start], working[end]);
+                double dist = geodesic
+                    ? distance_between(working[i],
+                          closest_point_on_segment(working[i], working[start], working[end]))
+                    : distance_to_segment(working[i], working[start], working[end]);
                 if (dist > max_dist) {
                     max_dist = dist;
                     max_idx = i;

--- a/include/geo/spherical.hpp
+++ b/include/geo/spherical.hpp
@@ -180,6 +180,38 @@ template <typename Path>
 }
 
 /**
+ * Returns the point that lies the given distance (in meters) along the path
+ * from its first vertex — "where is the vehicle after N meters of route".
+ * The distance is clamped to the path: values <= 0 return the first vertex
+ * and values >= path_length(path) return the last one, both with their
+ * coordinates exactly as given. Returns std::nullopt for an empty path.
+ */
+template <typename Path>
+[[nodiscard]] std::optional<LatLng> point_at_distance(const Path& path, double distance) {
+    const std::size_t size = path.size();
+    if (size == 0U) {
+        return std::nullopt;
+    }
+    LatLng prev(path[0].lat, path[0].lng);
+    if (distance <= 0.0) {
+        return prev;
+    }
+    // Segment lengths use the same formula as path_length, so a distance of
+    // path_length(path) lands on the last vertex (up to clamping).
+    double remaining = distance / detail::kEarthRadius;
+    for (std::size_t i = 1; i < size; ++i) {
+        const LatLng cur(path[i].lat, path[i].lng);
+        const double segment = angle_between(prev, cur);
+        if (remaining <= segment) {
+            return segment <= 0.0 ? cur : interpolate(prev, cur, remaining / segment);
+        }
+        remaining -= segment;
+        prev = cur;
+    }
+    return prev;
+}
+
+/**
  * Returns the signed area of a closed path on Earth, in square meters.
  *
  * Sign convention: counter-clockwise when viewed from outside the "inside"

--- a/include/geo/version.hpp
+++ b/include/geo/version.hpp
@@ -1,0 +1,26 @@
+// Copyright 2026 Aleksandr Kovalko
+// Licensed under the Apache License, Version 2.0
+
+#pragma once
+
+// Library version, kept in sync with the CMake project() version. This is a
+// static header (not configure_file-generated) so that copy-the-headers
+// consumers get it too; the test suite asserts it matches the CMake version.
+#define GEO_UTILS_CPP_VERSION_MAJOR 1
+#define GEO_UTILS_CPP_VERSION_MINOR 1
+#define GEO_UTILS_CPP_VERSION_PATCH 0
+
+// Single number for >= comparisons: major * 10000 + minor * 100 + patch,
+// e.g. 1.2.3 -> 10203.
+#define GEO_UTILS_CPP_VERSION                                        \
+    (GEO_UTILS_CPP_VERSION_MAJOR * 10000 + GEO_UTILS_CPP_VERSION_MINOR * 100 + \
+     GEO_UTILS_CPP_VERSION_PATCH)
+
+#define GEO_UTILS_CPP_VERSION_STR_(x) #x
+#define GEO_UTILS_CPP_VERSION_STR(x) GEO_UTILS_CPP_VERSION_STR_(x)
+
+// "major.minor.patch", e.g. "1.1.0".
+#define GEO_UTILS_CPP_VERSION_STRING                  \
+    GEO_UTILS_CPP_VERSION_STR(GEO_UTILS_CPP_VERSION_MAJOR) \
+    "." GEO_UTILS_CPP_VERSION_STR(GEO_UTILS_CPP_VERSION_MINOR) \
+    "." GEO_UTILS_CPP_VERSION_STR(GEO_UTILS_CPP_VERSION_PATCH)

--- a/tests/bounds/bounds.hpp
+++ b/tests/bounds/bounds.hpp
@@ -1,0 +1,149 @@
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <vector>
+
+#include <geo/bounds.hpp>
+#include <geo/poly.hpp>
+#include "../test_helpers.hpp"
+
+using geo::LatLng;
+using geo::LatLngBounds;
+
+TEST(Bounds, is_valid) {
+    EXPECT_TRUE (LatLngBounds({-10, -20}, {10, 20}).is_valid());
+    EXPECT_TRUE (LatLngBounds({-10, 170}, {10, -170}).is_valid());  // crosses AM
+    EXPECT_TRUE (LatLngBounds({0, 0}, {0, 0}).is_valid());          // degenerate point
+    EXPECT_FALSE(LatLngBounds({10, 0}, {-10, 0}).is_valid());       // lat inverted
+    EXPECT_FALSE(LatLngBounds({0, 200}, {10, 0}).is_valid());       // lng out of range
+    constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(LatLngBounds({nan, 0}, {10, 0}).is_valid());
+}
+
+TEST(Bounds, contains) {
+    LatLngBounds box({-10, -20}, {10, 20});
+    EXPECT_TRUE (box.contains({0, 0}));
+    EXPECT_TRUE (box.contains({-10, -20}));  // corners inclusive
+    EXPECT_TRUE (box.contains({10, 20}));
+    EXPECT_TRUE (box.contains({0, 20}));     // edges inclusive
+    EXPECT_FALSE(box.contains({10.0001, 0}));
+    EXPECT_FALSE(box.contains({0, 20.0001}));
+    EXPECT_FALSE(box.contains({0, 180}));
+
+    // Bounds crossing the antimeridian: sw.lng > ne.lng.
+    LatLngBounds am({-10, 170}, {10, -170});
+    EXPECT_TRUE (am.contains({0, 175}));
+    EXPECT_TRUE (am.contains({0, 180}));
+    EXPECT_TRUE (am.contains({0, -180}));    // 180 and -180 interchangeable
+    EXPECT_TRUE (am.contains({0, -175}));
+    EXPECT_FALSE(am.contains({0, 0}));
+    EXPECT_FALSE(am.contains({0, 160}));
+    EXPECT_FALSE(am.contains({11, 175}));
+
+    // Equal longitudes describe a single meridian, not the whole circle.
+    LatLngBounds meridian({-10, 30}, {10, 30});
+    EXPECT_TRUE (meridian.contains({0, 30}));
+    EXPECT_FALSE(meridian.contains({0, 30.0001}));
+    EXPECT_FALSE(meridian.contains({0, 29.9999}));
+}
+
+TEST(Bounds, extend) {
+    // Points already inside leave the bounds bit-exact.
+    LatLngBounds box({-10, -20}, {10, 20});
+    box.extend({0, 0});
+    EXPECT_EQ(box.southwest.lat, -10.0);
+    EXPECT_EQ(box.southwest.lng, -20.0);
+    EXPECT_EQ(box.northeast.lat, 10.0);
+    EXPECT_EQ(box.northeast.lng, 20.0);
+
+    // Latitude extends independently of longitude.
+    box.extend({15, 0});
+    EXPECT_EQ(box.northeast.lat, 15.0);
+    box.extend({-25, 0});
+    EXPECT_EQ(box.southwest.lat, -25.0);
+
+    // Longitude extends toward the nearer side.
+    box.extend({0, 30});   // 10 east of ne vs 310 west of sw
+    EXPECT_EQ(box.northeast.lng, 30.0);
+    box.extend({0, -40});  // 20 west of sw vs 290 east of ne
+    EXPECT_EQ(box.southwest.lng, -40.0);
+
+    // Extending across the antimeridian flips sw/ne longitude order.
+    LatLngBounds pacific({0, 160}, {10, 175});
+    pacific.extend({5, -170});  // 15 east of 175 vs 330 west of 160
+    EXPECT_EQ(pacific.northeast.lng, -170.0);
+    EXPECT_TRUE(pacific.contains({5, 180}));
+    EXPECT_FALSE(pacific.contains({5, 0}));
+
+    // Reaching the 180 meridian eastward stores +180 (not -180), keeping
+    // the eastward span minimal.
+    LatLngBounds east({0, 90}, {10, 170});
+    east.extend({5, -180});
+    EXPECT_EQ(east.northeast.lng, 180.0);
+    EXPECT_NEAR(east.lng_span(), 90.0, 1e-12);
+
+    // ...and reaching it westward stores -180.
+    LatLngBounds west({0, -170}, {10, -90});
+    west.extend({5, 180});
+    EXPECT_EQ(west.southwest.lng, -180.0);
+    EXPECT_NEAR(west.lng_span(), 90.0, 1e-12);
+}
+
+TEST(Bounds, center) {
+    EXPECT_NEAR_LatLng(LatLng(0, 0), LatLngBounds({-10, -20}, {10, 20}).center());
+    EXPECT_NEAR_LatLng(LatLng(5, 15), LatLngBounds({0, 10}, {10, 20}).center());
+
+    // Antimeridian-crossing bounds: the center is on the far side.
+    EXPECT_NEAR_LatLng(LatLng(0, 180), LatLngBounds({-10, 170}, {10, -170}).center());
+    EXPECT_NEAR_LatLng(LatLng(0, -175), LatLngBounds({-10, 170}, {10, -160}).center());
+}
+
+TEST(Bounds, intersects) {
+    LatLngBounds box({-10, -20}, {10, 20});
+    EXPECT_TRUE (box.intersects(LatLngBounds({0, 0}, {30, 40})));      // overlap
+    EXPECT_TRUE (box.intersects(LatLngBounds({-5, -5}, {5, 5})));      // nested
+    EXPECT_TRUE (box.intersects(LatLngBounds({10, 20}, {30, 40})));    // touching corner
+    EXPECT_FALSE(box.intersects(LatLngBounds({20, 0}, {30, 10})));     // disjoint lat
+    EXPECT_FALSE(box.intersects(LatLngBounds({0, 30}, {10, 40})));     // disjoint lng
+    EXPECT_FALSE(box.intersects(LatLngBounds({-10, 170}, {10, -170})));
+
+    // Antimeridian-crossing vs plain bounds.
+    LatLngBounds am({-10, 170}, {10, -170});
+    EXPECT_TRUE (am.intersects(LatLngBounds({0, 175}, {5, 178})));     // nested in AM box
+    EXPECT_TRUE (am.intersects(LatLngBounds({0, -175}, {5, -160})));   // overlaps east side
+    EXPECT_TRUE (am.intersects(LatLngBounds({0, 100}, {5, 175})));     // overlaps west side
+    EXPECT_FALSE(am.intersects(LatLngBounds({0, -100}, {5, 100})));
+    EXPECT_TRUE (am.intersects(LatLngBounds({-10, -170}, {10, 170}))); // complement, shares edges
+}
+
+TEST(Bounds, bounds_of_path) {
+    // Empty path: no bounds.
+    EXPECT_FALSE(geo::bounds(std::vector<LatLng>{}).has_value());
+
+    // Single point: degenerate bounds containing exactly that point.
+    auto single = geo::bounds(std::vector<LatLng>{ {45, 45} });
+    ASSERT_TRUE(single.has_value());
+    EXPECT_TRUE(single->contains({45, 45}));
+    EXPECT_EQ(single->lng_span(), 0.0);
+
+    // A small polygon: every vertex and interior point is inside; the
+    // bounds work as a prefilter for contains().
+    std::vector<LatLng> tri = { {0, 0}, {10, 12}, {20, 5} };
+    auto tri_bounds = geo::bounds(tri);
+    ASSERT_TRUE(tri_bounds.has_value());
+    EXPECT_EQ(tri_bounds->southwest.lat, 0.0);
+    EXPECT_EQ(tri_bounds->southwest.lng, 0.0);
+    EXPECT_EQ(tri_bounds->northeast.lat, 20.0);
+    EXPECT_EQ(tri_bounds->northeast.lng, 12.0);
+    for (const auto& p : { LatLng(10, 11), LatLng(19, 5), LatLng(1, 1) }) {
+        EXPECT_TRUE(geo::contains(p, tri) ? tri_bounds->contains(p) : true);
+    }
+    EXPECT_FALSE(tri_bounds->contains({30, 5}));   // outside bounds => outside polygon
+
+    // A route crossing the antimeridian gets tight (not world-spanning) bounds.
+    auto am = geo::bounds(std::vector<LatLng>{ {10, 170}, {20, -170} });
+    ASSERT_TRUE(am.has_value());
+    EXPECT_NEAR(am->lng_span(), 20.0, 1e-12);
+    EXPECT_TRUE(am->contains({15, 180}));
+    EXPECT_FALSE(am->contains({15, 0}));
+}

--- a/tests/encoding/decode.hpp
+++ b/tests/encoding/decode.hpp
@@ -45,6 +45,23 @@ TEST(Encoding, decode_adversarial_overflow) {
     EXPECT_EQ(decode(adversarial).size(), 3U);
 }
 
+TEST(Encoding, decode_precision) {
+    // polyline6 reference vector from the mapbox/polyline test suite.
+    auto path = decode("_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI", 6);
+    ASSERT_EQ(path.size(), 3U);
+    EXPECT_TRUE(path[0].approx_equal(LatLng(38.5, -120.2), 1e-9));
+    EXPECT_TRUE(path[1].approx_equal(LatLng(40.7, -120.95), 1e-9));
+    EXPECT_TRUE(path[2].approx_equal(LatLng(43.252, -126.453), 1e-9));
+
+    // The default precision is 5.
+    auto classic = decode("_p~iF~ps|U_ulLnnqC_mqNvxq`@");
+    auto explicit5 = decode("_p~iF~ps|U_ulLnnqC_mqNvxq`@", 5);
+    ASSERT_EQ(classic.size(), explicit5.size());
+    for (std::size_t i = 0; i < classic.size(); ++i) {
+        EXPECT_EQ(classic[i], explicit5[i]);
+    }
+}
+
 TEST(Encoding, encode_decode_roundtrip) {
     std::vector<LatLng> path = {
         {0, 0}, {90, 180}, {-90, -180}, {1.00001, -1.00001},
@@ -55,5 +72,26 @@ TEST(Encoding, encode_decode_roundtrip) {
     for (std::size_t i = 0; i < path.size(); ++i) {
         // Quantization to 1e-5 degrees: round-trip error is at most 5e-6.
         EXPECT_TRUE(decoded[i].approx_equal(path[i], 1e-5)) << decoded[i];
+    }
+
+    // Precision 6: the round-trip error shrinks to 5e-7. Unlike 7+, every
+    // valid coordinate and every point-to-point delta (up to ±360° of
+    // longitude) still fits the decoder's 32-bit arithmetic.
+    auto decoded6 = decode(encode(path, 6), 6);
+    ASSERT_EQ(decoded6.size(), path.size());
+    for (std::size_t i = 0; i < path.size(); ++i) {
+        EXPECT_TRUE(decoded6[i].approx_equal(path[i], 1e-6)) << decoded6[i];
+    }
+
+    // Precision 7 round-trips paths whose deltas stay within ~107°  — that
+    // includes the first point, whose deltas are taken from (0, 0); larger
+    // deltas overflow the 32-bit zig-zag.
+    std::vector<LatLng> nearby = {
+        {38.5, -100.2}, {40.7, -100.95}, {43.252, -106.453}, {-38.5, -20.2},
+    };
+    auto decoded7 = decode(encode(nearby, 7), 7);
+    ASSERT_EQ(decoded7.size(), nearby.size());
+    for (std::size_t i = 0; i < nearby.size(); ++i) {
+        EXPECT_TRUE(decoded7[i].approx_equal(nearby[i], 1e-7)) << decoded7[i];
     }
 }

--- a/tests/encoding/encode.hpp
+++ b/tests/encoding/encode.hpp
@@ -27,3 +27,19 @@ TEST(Encoding, encode) {
     std::vector<LatLng> b = { {38.500000004, -120.199999996} };
     EXPECT_EQ(encode(a), encode(b));
 }
+
+TEST(Encoding, encode_precision) {
+    // polyline6 reference vector from the mapbox/polyline test suite: the
+    // same three points as the classic example, on the 1e-6 grid.
+    std::vector<LatLng> path = { {38.5, -120.2}, {40.7, -120.95}, {43.252, -126.453} };
+    EXPECT_EQ(encode(path, 6), "_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI");
+
+    // The default precision is 5 — same string as the classic example.
+    EXPECT_EQ(encode(path, 5), encode(path));
+
+    // At precision 6, 1e-5-sized differences no longer collapse.
+    std::vector<LatLng> a = { {38.5, -120.2} };
+    std::vector<LatLng> b = { {38.500004, -120.199996} };
+    EXPECT_EQ(encode(a), encode(b));
+    EXPECT_NE(encode(a, 6), encode(b, 6));
+}

--- a/tests/fuzz/fuzz_decode.cpp
+++ b/tests/fuzz/fuzz_decode.cpp
@@ -36,8 +36,26 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size
     }
     if (all_valid) {
         for (std::size_t i = 0; i < decoded.size(); ++i) {
-            // Exact comparison on purpose: both sides are int32 * 1e-5.
+            // Exact comparison on purpose: both sides are int32 / 1e5.
             if (decoded[i].lat != redecoded[i].lat || decoded[i].lng != redecoded[i].lng) {
+                std::abort();
+            }
+        }
+    }
+
+    // Same properties on the polyline6 grid.
+    const std::vector<geo::LatLng> decoded6 = geo::decode(input, 6);
+    const std::vector<geo::LatLng> redecoded6 = geo::decode(geo::encode(decoded6, 6), 6);
+    if (redecoded6.size() != decoded6.size()) {
+        std::abort();
+    }
+    bool all_valid6 = true;
+    for (const auto& point : decoded6) {
+        all_valid6 = all_valid6 && point.is_valid();
+    }
+    if (all_valid6) {
+        for (std::size_t i = 0; i < decoded6.size(); ++i) {
+            if (decoded6[i].lat != redecoded6[i].lat || decoded6[i].lng != redecoded6[i].lng) {
                 std::abort();
             }
         }

--- a/tests/latlng/normalized.hpp
+++ b/tests/latlng/normalized.hpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+#include <geo/latlng.hpp>
+
+using geo::LatLng;
+
+TEST(LatLng, normalized) {
+    // In-range coordinates pass through bit-exactly.
+    LatLng nyc = LatLng(40.7128, -74.0060).normalized();
+    EXPECT_EQ(nyc.lat, 40.7128);
+    EXPECT_EQ(nyc.lng, -74.0060);
+    LatLng sw = LatLng(-90, -180).normalized();
+    EXPECT_EQ(sw.lat, -90.0);
+    EXPECT_EQ(sw.lng, -180.0);
+
+    // Longitude 180 wraps to -180 (same meridian, canonical form).
+    EXPECT_EQ(LatLng(0, 180).normalized().lng, -180.0);
+
+    // Latitude clamps.
+    EXPECT_EQ(LatLng(90.0001, 0).normalized().lat, 90.0);
+    EXPECT_EQ(LatLng(-90.0001, 0).normalized().lat, -90.0);
+    EXPECT_EQ(LatLng(180, 0).normalized().lat, 90.0);
+
+    // Longitude wraps by full turns.
+    EXPECT_DOUBLE_EQ(LatLng(0, 185).normalized().lng, -175.0);
+    EXPECT_DOUBLE_EQ(LatLng(0, -185).normalized().lng, 175.0);
+    EXPECT_DOUBLE_EQ(LatLng(0, 200).normalized().lng, -160.0);
+    EXPECT_DOUBLE_EQ(LatLng(0, -200).normalized().lng, 160.0);
+    EXPECT_DOUBLE_EQ(LatLng(0, 360).normalized().lng, 0.0);
+    EXPECT_DOUBLE_EQ(LatLng(0, 540).normalized().lng, -180.0);
+    EXPECT_DOUBLE_EQ(LatLng(0, -540).normalized().lng, -180.0);
+
+    // Any finite input normalizes to a valid coordinate.
+    EXPECT_TRUE(LatLng(1234.5, -6789.0).normalized().is_valid());
+    EXPECT_TRUE(LatLng(-1e15, 1e15).normalized().is_valid());
+
+    // Infinite latitude clamps; infinite longitude has no meaningful wrap.
+    constexpr double inf = std::numeric_limits<double>::infinity();
+    EXPECT_EQ(LatLng(inf, 0).normalized().lat, 90.0);
+    EXPECT_EQ(LatLng(-inf, 0).normalized().lat, -90.0);
+    EXPECT_TRUE(std::isnan(LatLng(0, inf).normalized().lng));
+
+    // NaN propagates: normalizing garbage does not invent a coordinate.
+    constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_TRUE(std::isnan(LatLng(nan, 0).normalized().lat));
+    EXPECT_TRUE(std::isnan(LatLng(0, nan).normalized().lng));
+    EXPECT_FALSE(LatLng(nan, nan).normalized().is_valid());
+}

--- a/tests/poly/closest_point_on_path.hpp
+++ b/tests/poly/closest_point_on_path.hpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include <geo/poly.hpp>
+#include "../test_helpers.hpp"
+
+using geo::LatLng;
+using geo::closest_point_on_path;
+using geo::distance_between;
+
+TEST(Poly, closest_point_on_path) {
+    // Empty path: no closest point.
+    std::vector<LatLng> empty;
+    EXPECT_FALSE(closest_point_on_path(LatLng(0, 0), empty).has_value());
+
+    // Single point: the point itself, segment index 0.
+    std::vector<LatLng> one = { {45, 45} };
+    auto r1 = closest_point_on_path(LatLng(0, 0), one);
+    ASSERT_TRUE(r1.has_value());
+    EXPECT_EQ(r1->point.lat, 45.0);
+    EXPECT_EQ(r1->point.lng, 45.0);
+    EXPECT_EQ(r1->segment, 0U);
+    EXPECT_DOUBLE_EQ(r1->distance, distance_between(LatLng(0, 0), r1->point));
+
+    // An L-shaped route: equator leg, then a meridian leg.
+    std::vector<LatLng> route = { {0, 0}, {0, 10}, {10, 10} };
+
+    // Clearly nearest to the first leg.
+    auto r2 = closest_point_on_path(LatLng(2, 5), route);
+    ASSERT_TRUE(r2.has_value());
+    EXPECT_EQ(r2->segment, 0U);
+    EXPECT_NEAR_LatLng(LatLng(0, 5), r2->point);
+    EXPECT_DOUBLE_EQ(r2->distance, distance_between(LatLng(2, 5), r2->point));
+
+    // Clearly nearest to the second leg: the foot keeps ~the latitude.
+    auto r3 = closest_point_on_path(LatLng(8, 9.5), route);
+    ASSERT_TRUE(r3.has_value());
+    EXPECT_EQ(r3->segment, 1U);
+    EXPECT_NEAR(r3->point.lng, 10.0, 1e-9);
+    EXPECT_NEAR(r3->point.lat, 8.0, 0.01);
+    EXPECT_DOUBLE_EQ(r3->distance, distance_between(LatLng(8, 9.5), r3->point));
+
+    // A point of the route itself: distance ~0, first matching segment.
+    auto r4 = closest_point_on_path(geo::interpolate(route[0], route[1], 0.3), route);
+    ASSERT_TRUE(r4.has_value());
+    EXPECT_EQ(r4->segment, 0U);
+    EXPECT_LT(r4->distance, 1e-6);
+}
+
+TEST(Poly, closest_point_on_path_shared_vertex_tie) {
+    // Both legs are closest at their shared vertex: the tie goes to the
+    // lower segment index, and the vertex coordinates come back bit-exact.
+    std::vector<LatLng> route = { {0, 0}, {0, 10}, {10, 10} };
+    auto r = closest_point_on_path(LatLng(-5, 15), route);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->segment, 0U);
+    EXPECT_EQ(r->point.lat, 0.0);
+    EXPECT_EQ(r->point.lng, 10.0);
+    EXPECT_DOUBLE_EQ(r->distance, distance_between(LatLng(-5, 15), r->point));
+}
+
+TEST(Poly, closest_point_on_path_antimeridian) {
+    // Route crossing the antimeridian; the probe sits right on lng 180.
+    std::vector<LatLng> route = { {0, 170}, {0, -170}, {5, -170} };
+    auto r = closest_point_on_path(LatLng(1, 180), route);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->segment, 0U);
+    EXPECT_NEAR_LatLng(LatLng(0, 180), r->point);
+    EXPECT_NEAR(r->distance, geo::detail::deg2rad(1.0) * geo::detail::kEarthRadius, 1e-3);
+}

--- a/tests/poly/closest_point_on_segment.hpp
+++ b/tests/poly/closest_point_on_segment.hpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include <geo/poly.hpp>
+#include "../test_helpers.hpp"
+
+using geo::LatLng;
+using geo::closest_point_on_segment;
+using geo::distance_between;
+using geo::distance_to_segment;
+
+TEST(Poly, closest_point_on_segment) {
+    const LatLng a(0, 0);
+    const LatLng b(0, 90);
+
+    // A point on the segment maps to itself.
+    EXPECT_NEAR_LatLng(LatLng(0, 45), closest_point_on_segment(LatLng(0, 45), a, b));
+
+    // Perpendicular foot: on the equator the closest point keeps the
+    // longitude, from either side.
+    EXPECT_NEAR_LatLng(LatLng(0, 30), closest_point_on_segment(LatLng( 20, 30), a, b));
+    EXPECT_NEAR_LatLng(LatLng(0, 30), closest_point_on_segment(LatLng(-20, 30), a, b));
+
+    // Projection falls outside the arc: the nearer endpoint is returned,
+    // with its coordinates bit-exact.
+    LatLng before = closest_point_on_segment(LatLng(10, -20), a, b);
+    EXPECT_EQ(before.lat, a.lat);
+    EXPECT_EQ(before.lng, a.lng);
+    LatLng after = closest_point_on_segment(LatLng(-10, 100), a, b);
+    EXPECT_EQ(after.lat, b.lat);
+    EXPECT_EQ(after.lng, b.lng);
+
+    // Degenerate segment: start == end yields start.
+    LatLng same = closest_point_on_segment(LatLng(0, 0), LatLng(45, 45), LatLng(45, 45));
+    EXPECT_EQ(same.lat, 45.0);
+    EXPECT_EQ(same.lng, 45.0);
+
+    // Antipodal endpoints: no unique great circle — the nearer endpoint.
+    LatLng anti = closest_point_on_segment(LatLng(10, 20), LatLng(0, 0), LatLng(0, 180));
+    EXPECT_EQ(anti.lat, 0.0);
+    EXPECT_EQ(anti.lng, 0.0);
+
+    // Point at a pole of the segment's great circle: the whole circle is a
+    // quarter-circumference away, so an endpoint is a correct answer.
+    LatLng pole = closest_point_on_segment(LatLng(90, 0), a, b);
+    EXPECT_EQ(pole.lat, a.lat);
+    EXPECT_EQ(pole.lng, a.lng);
+    EXPECT_NEAR(distance_between(LatLng(90, 0), pole),
+                geo::detail::kPi / 2 * geo::detail::kEarthRadius, 1e-3);
+}
+
+TEST(Poly, closest_point_on_segment_high_latitude) {
+    // The great circle between two points at latitude 80 bulges poleward:
+    // its vertex latitude is atan(tan(80°) / cos(45°)) ≈ 82.89°, not 80.
+    // The planar distance_to_segment misses this entirely (it projects in
+    // raw lat/lng space and snaps to an endpoint here).
+    const LatLng a(80, 0);
+    const LatLng b(80, 90);
+    const LatLng pole(90, 0);
+
+    LatLng c = closest_point_on_segment(pole, a, b);
+    double peak_lat = geo::detail::rad2deg(
+        std::atan(std::tan(geo::detail::deg2rad(80.0)) / std::cos(geo::detail::deg2rad(45.0))));
+    EXPECT_NEAR(c.lat, peak_lat, 1e-9);  // ≈ 82.8935
+    EXPECT_NEAR(c.lng, 45.0, 1e-9);
+
+    // Geodesic distance ≈ 790 km; the planar approximation reports ≈ 1112 km.
+    double geodesic = distance_between(pole, c);
+    EXPECT_NEAR(geodesic, geo::detail::deg2rad(90.0 - peak_lat) * geo::detail::kEarthRadius, 1e-6);
+    EXPECT_LT(geodesic, distance_to_segment(pole, a, b) - 300'000.0);
+}
+
+TEST(Poly, closest_point_on_segment_antimeridian) {
+    // Segment crossing the antimeridian — meaningless for the planar
+    // distance_to_segment, exact here: the foot keeps the longitude.
+    LatLng c = closest_point_on_segment(LatLng(5, 180), LatLng(0, 170), LatLng(0, -170));
+    EXPECT_NEAR_LatLng(LatLng(0, 180), c);
+    EXPECT_NEAR(distance_between(LatLng(5, 180), c),
+                geo::detail::deg2rad(5.0) * geo::detail::kEarthRadius, 1e-3);
+
+    // Both endpoints on one side, point on the other.
+    LatLng d = closest_point_on_segment(LatLng(0, -179), LatLng(10, 179), LatLng(-10, 179));
+    EXPECT_NEAR_LatLng(LatLng(0, 179), d);
+}
+
+TEST(Poly, closest_point_on_segment_brute_force) {
+    // Property test with a fixed seed: for random segments and points, the
+    // returned point must lie on the segment, and no densely sampled point
+    // of the arc may be meaningfully closer.
+    std::mt19937 rng(20260702u);
+    std::uniform_real_distribution<double> rand_lat(-90.0, 90.0);
+    std::uniform_real_distribution<double> rand_lng(-180.0, 180.0);
+    const int kSamples = 1000;
+
+    for (int trial = 0; trial < 150; ++trial) {
+        const LatLng a(rand_lat(rng), rand_lng(rng));
+        const LatLng b(rand_lat(rng), rand_lng(rng));
+        const LatLng p(rand_lat(rng), rand_lng(rng));
+        // Skip near-antipodal segments: the great circle is not unique and
+        // the nearer-endpoint convention would not match arc sampling.
+        if (geo::angle_between(a, b) > geo::detail::kPi - 1e-3) {
+            continue;
+        }
+
+        const LatLng c = closest_point_on_segment(p, a, b);
+        const double d = distance_between(p, c);
+
+        EXPECT_TRUE(geo::on_path(c, std::vector<LatLng>{a, b}, true, 1e-2))
+            << "trial " << trial << ": " << c << " not on " << a << " .. " << b;
+
+        double sampled = std::numeric_limits<double>::infinity();
+        for (int k = 0; k <= kSamples; ++k) {
+            sampled = std::min(sampled,
+                distance_between(p, geo::interpolate(a, b, static_cast<double>(k) / kSamples)));
+        }
+        EXPECT_LE(d, sampled + 1e-3)
+            << "trial " << trial << ": " << p << " -> " << c << " misses a closer arc point";
+    }
+}

--- a/tests/poly/simplify.hpp
+++ b/tests/poly/simplify.hpp
@@ -97,6 +97,32 @@ TEST(Poly, simplify_triangle) {
     expect_simplified(triangle, simplified_closed);
 }
 
+TEST(Poly, simplify_geodesic) {
+    // Antimeridian-crossing polyline: the middle vertex sits ~11 m off the
+    // segment. The default planar metric sees raw longitudes spanning almost
+    // the whole globe, measures kilometers, and keeps the vertex; the
+    // geodesic metric measures the true 11 m and drops it.
+    std::vector<LatLng> am = { {0, 179}, {0.0001, -179.95}, {0, -179.9} };
+    EXPECT_EQ(simplify(am, 50.0, /*geodesic=*/false).size(), 3U);
+    EXPECT_EQ(simplify(am, 50.0, /*geodesic=*/true).size(), 2U);
+
+    // Away from the antimeridian at low latitudes the two metrics agree:
+    // the upstream 95-point line simplifies to the same sizes.
+    static const char kLine[] =
+        "elfjD~a}uNOnFN~Em@fJv@tEMhGDjDe@hG^nF??@lA?n@IvAC`Ay@A{@DwCA{CF_EC{CEi@PBTFDJBJ?V?n@?D@?A@?@?F?F?"
+        "LAf@?n@@`@@T@~@FpA?fA?p@?r@?vAH`@OR@^ETFJCLD?JA^?J?P?fAC`B@d@?b@A\\@`@Ad@@\\?`@?f@?V?H?DD@DDBBDBD?"
+        "D?B?B@B@@@B@B@B@D?D?JAF@H@FCLADBDBDCFAN?b@Af@@x@@";
+    const std::vector<LatLng> line = decode(kLine);
+    const std::pair<double, std::size_t> expected[] = {
+        {5, 20}, {10, 14}, {50, 6}, {1000, 2},
+    };
+    for (const auto& [tolerance, size] : expected) {
+        auto simplified = simplify(line, tolerance, /*geodesic=*/true);
+        EXPECT_EQ(simplified.size(), size) << "tolerance = " << tolerance;
+        expect_simplified(line, simplified);
+    }
+}
+
 TEST(Poly, simplify_oval) {
     // Oval polygon from the upstream test suite.
     static const char kOval[] =

--- a/tests/spherical/point_at_distance.hpp
+++ b/tests/spherical/point_at_distance.hpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include <geo/spherical.hpp>
+#include "../test_helpers.hpp"
+
+using geo::LatLng;
+using geo::distance_between;
+using geo::path_length;
+using geo::point_at_distance;
+
+TEST(Spherical, point_at_distance) {
+    // Empty path: no point.
+    EXPECT_FALSE(point_at_distance(std::vector<LatLng>{}, 100.0).has_value());
+
+    // Single point: always that point, whatever the distance.
+    std::vector<LatLng> one = { {45, 45} };
+    EXPECT_EQ(point_at_distance(one, 0.0)->lat, 45.0);
+    EXPECT_EQ(point_at_distance(one, 1e7)->lng, 45.0);
+
+    // Along the equator: distance maps linearly to longitude.
+    std::vector<LatLng> equator = { {0, 0}, {0, 10} };
+    const double len = path_length(equator);
+    EXPECT_NEAR_LatLng(LatLng(0, 2.5), *point_at_distance(equator, len * 0.25));
+    EXPECT_NEAR_LatLng(LatLng(0, 5.0), *point_at_distance(equator, len * 0.5));
+
+    // Clamping: <= 0 returns the first vertex, >= length the last — both
+    // with the original coordinates bit-exact.
+    EXPECT_EQ(point_at_distance(equator, 0.0)->lng, 0.0);
+    EXPECT_EQ(point_at_distance(equator, -5.0)->lng, 0.0);
+    EXPECT_EQ(point_at_distance(equator, len * 2)->lng, 10.0);
+
+    // Multi-segment route: distances land on the right leg.
+    std::vector<LatLng> route = { {0, 0}, {0, 10}, {10, 10} };
+    const double leg0 = distance_between(route[0], route[1]);
+    EXPECT_NEAR_LatLng(route[1], *point_at_distance(route, leg0));
+    auto second_leg = *point_at_distance(route, leg0 + distance_between(route[1], route[2]) / 2);
+    EXPECT_NEAR(second_leg.lng, 10.0, 1e-9);
+    EXPECT_NEAR(second_leg.lat, 5.0, 0.01);
+
+    // The full length reaches the last vertex.
+    EXPECT_NEAR_LatLng(route[2], *point_at_distance(route, path_length(route)));
+
+    // Repeated vertices (zero-length segments) are skipped safely.
+    std::vector<LatLng> repeated = { {0, 0}, {0, 0}, {0, 10} };
+    EXPECT_NEAR_LatLng(LatLng(0, 5), *point_at_distance(repeated, path_length(repeated) / 2));
+
+    // Across the antimeridian: the midpoint of a 170 -> -170 hop is lng 180.
+    std::vector<LatLng> am = { {0, 170}, {0, -170} };
+    EXPECT_NEAR_LatLng(LatLng(0, 180), *point_at_distance(am, path_length(am) / 2));
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,4 +1,6 @@
 /** Including all tests */
+#include "bounds/bounds.hpp"
+
 #include "latlng/is_valid.hpp"
 #include "latlng/normalized.hpp"
 #include "latlng/operator_equal.hpp"

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -13,6 +13,7 @@
 #include "spherical/offset.hpp"
 #include "spherical/offset_origin.hpp"
 #include "spherical/path_length.hpp"
+#include "spherical/point_at_distance.hpp"
 #include "spherical/signed_area.hpp"
 
 #include "poly/closest_point_on_path.hpp"

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -30,6 +30,8 @@
 #include "encoding/decode.hpp"
 #include "encoding/encode.hpp"
 
+#include "version/version.hpp"
+
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,5 +1,6 @@
 /** Including all tests */
 #include "latlng/is_valid.hpp"
+#include "latlng/normalized.hpp"
 #include "latlng/operator_equal.hpp"
 
 #include "math/mod.hpp"

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -14,6 +14,8 @@
 #include "spherical/path_length.hpp"
 #include "spherical/signed_area.hpp"
 
+#include "poly/closest_point_on_path.hpp"
+#include "poly/closest_point_on_segment.hpp"
 #include "poly/contains.hpp"
 #include "poly/distance_to_segment.hpp"
 #include "poly/is_closed_polygon.hpp"

--- a/tests/version/version.hpp
+++ b/tests/version/version.hpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include <geo/version.hpp>
+
+// The version macros are usable in preprocessor and constant expressions.
+static_assert(GEO_UTILS_CPP_VERSION ==
+              GEO_UTILS_CPP_VERSION_MAJOR * 10000 +
+              GEO_UTILS_CPP_VERSION_MINOR * 100 +
+              GEO_UTILS_CPP_VERSION_PATCH);
+#if GEO_UTILS_CPP_VERSION < 10100
+#error "version macro must be usable in #if"
+#endif
+
+TEST(Version, matches_cmake_project_version) {
+    // GEO_UTILS_CPP_TEST_CMAKE_VERSION is injected by the test CMakeLists
+    // from ${PROJECT_VERSION}. If this fails, a release bumped one version
+    // and not the other — see RELEASING.md.
+    EXPECT_STREQ(GEO_UTILS_CPP_VERSION_STRING, GEO_UTILS_CPP_TEST_CMAKE_VERSION);
+}


### PR DESCRIPTION
The batch of improvements picked for 1.2.0 — one commit per item, reviewable independently.

> **Stacked on #37**: the first commit (`eb15332`) is a cherry-pick of #37 (`closest_point_on_segment`/`closest_point_on_path`), which the geodesic-simplify commit and the example build on. Merge #37 first and I'll rebase this branch — the duplicate commit drops out automatically.

## Commits

1. **`LatLng::normalized()`** — clamp lat to [-90, 90], wrap lng to [-180, 180) (Android SDK conventions); in-range values pass through bit-exactly, NaN propagates so garbage stays `!is_valid()`.
2. **Polyline precision (`encode`/`decode`, default 5)** — `6` = polyline6 (OSRM/Valhalla/Mapbox), golden vector from the mapbox/polyline test suite; default output stays byte-identical. Documented the real limit: 6 is the highest fully-safe precision (at 7 the 32-bit zig-zag overflows on deltas beyond ~107°, first point included — found by the round-trip test). `decode` now divides by the grid factor (exact at every precision). Fuzz harness round-trips the polyline6 grid too.
3. **`simplify(..., geodesic = true)`** — measures against true great-circle segments via `closest_point_on_segment`; default stays bit-compatible with upstream PolyUtil. Test: an antimeridian polyline where the planar metric keeps an 11 m-off vertex at 50 m tolerance and the geodesic metric correctly drops it.
4. **`point_at_distance(path, meters)`** — the "position N meters along the route" companion of `path_length` (same length formula, so `path_length(path)` lands exactly on the last vertex); clamps to the path, endpoint results bit-exact.
5. **`LatLngBounds` + `bounds(path)`** — viewport math and a prefilter for `contains`/`on_path`. Eastward-span semantics make antimeridian-crossing bounds first-class; `extend` follows Android-builder semantics with a span-minimal choice at the 180 meridian. `intersects` cross-checked against 200k randomized box pairs beyond the unit tests.
6. **`<geo/version.hpp>`** — `GEO_UTILS_CPP_VERSION*` macros usable in `#if`; a test compares them against the CMake `project()` version so a release can't bump one without the other.
7. **`examples/gps_track.cpp`** — end-to-end pipeline on a real 95-point track: decode → bounds → geodesic simplify → snap a GPS fix → `point_at_distance` → re-encode as polyline6; self-verifying, registered in ctest.
8. **Benchmarks** (`docs/benchmarks.md` updated, same M1 host): snap vs `S2Polyline::Project` (S2 ~3× — entirely its pre-built unit vectors, same asymmetry as `path_length`), `point_at_distance` vs `S2Polyline::Interpolate` (**we win 1.6–1.9×**), simplify geodesic-vs-planar cost (1.3–2.6×, docstrings updated accordingly).

## Verification

- 73/73 tests (was 65 on master+#37), plain **and** under ASan/UBSan locally; umbrella header compiles clean with `-Wall -Wextra -Wpedantic -Wconversion -Werror`.
- Example runs with asserts active (default build type, like CI).
- Benchmarks built with S2 0.14.0 present; numbers are medians of 5 repetitions.