### PR TITLE
Add native Meson build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@
 #   - sanitizers: the same test suite under ASan + UBSan (clang)
 #   - single-header: generate the amalgamation and build the example with it
 #   - fuzz-smoke: a short libFuzzer run over geo::decode (clang)
+#   - meson: configure the native Meson build and run the example as a smoke test
 #
 # Triggered automatically on push/PR to master/main; can also be run manually
 # from the Actions tab in GitHub UI.
@@ -160,3 +161,25 @@ jobs:
 
       - name: Fuzz
         run: ./build-fuzz/tests/fuzz/geo_utils_cpp_fuzz_decode -max_total_time=60 -print_final_stats=1
+
+  # Native Meson build. Keeps meson.build from drifting out of sync with the
+  # header layout: a standalone configure builds the self-verifying gps_track
+  # example, which `meson test` then runs as an end-to-end smoke test.
+  meson:
+    name: meson-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Meson + Ninja
+        run: pip install meson ninja
+
+      - name: Setup
+        run: meson setup build-meson
+
+      - name: Test
+        run: meson test -C build-meson --print-errorlogs

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,45 @@
+# Native Meson build for geo-utils-cpp.
+#
+# The library is header-only, so this does three things:
+#   * expose an internal dependency (declare_dependency) so the project can be
+#     consumed as a Meson subproject / WrapDB wrap,
+#   * install the headers for a system-wide `meson install`,
+#   * optionally build the self-verifying example as a smoke test.
+#
+# Keep `version` in sync with CMakeLists.txt's project(VERSION ...) and
+# include/geo/version.hpp -- the test suite asserts they agree.
+project(
+  'geo-utils-cpp',
+  'cpp',
+  version: '1.2.1',
+  license: 'Apache-2.0',
+  default_options: ['cpp_std=c++17'],
+  meson_version: '>=0.56.0',
+)
+
+geo_utils_cpp_dep = declare_dependency(
+  include_directories: include_directories('include'),
+)
+
+# Lets `dependency('geo-utils-cpp')` resolve without a find_package /
+# pkg-config round-trip when this repo is used as a subproject.
+meson.override_dependency('geo-utils-cpp', geo_utils_cpp_dep)
+
+install_subdir(
+  'include/geo',
+  install_dir: get_option('includedir'),
+)
+
+# Build the example only when standalone (or explicitly asked), so downstream
+# consumers don't compile our example into their build tree.
+tests_opt = get_option('tests')
+if not tests_opt.disabled() and (not meson.is_subproject() or tests_opt.enabled())
+  # examples/gps_track.cpp asserts its own results and returns non-zero on
+  # failure, so it doubles as an end-to-end smoke test.
+  smoke = executable(
+    'gps_track',
+    'examples/gps_track.cpp',
+    dependencies: geo_utils_cpp_dep,
+  )
+  test('gps_track', smoke)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'tests',
+  type: 'feature',
+  value: 'auto',
+  description: 'Build the self-verifying example (examples/gps_track.cpp) as a smoke test',
+)


### PR DESCRIPTION
Adds a native Meson build alongside the existing CMake/build2 ones, so the library is consumable as a Meson subproject / WrapDB wrap without a downstream-maintained build description.

## What's here

- **`meson.build`** — header-only: `declare_dependency` on `include/`, `meson.override_dependency('geo-utils-cpp', …)` so `dependency('geo-utils-cpp')` resolves in a consumer without pkg-config, and `install_subdir('include/geo')` for `meson install`.
- **`meson_options.txt`** — a `tests` feature (default `auto`). The self-verifying `examples/gps_track.cpp` is built standalone (or on `-Dtests=enabled`) and registered as a smoke test; it is **not** built when the library is pulled in as a subproject, so consumers don't compile our example into their tree.
- **`ci.yml`** — a `meson-build` job (`meson setup` + `meson test`) so the file can't drift out of sync with the header layout.

## Why

The [WrapDB PR](https://github.com/mesonbuild/wrapdb/pull/2820) currently carries the build description in a downstream packagefile that hardcodes our internal layout. Shipping Meson upstream lets the wrap drop that packagefile and carry only the `.wrap` (URL + hash) — the build description travels with the code and stays a single source of truth.

## Verified locally

- `meson test` → `gps_track` smoke test passes (AppleClang 17, arm64).
- Consumed as a subproject from a throwaway project: `dependency('geo-utils-cpp')` resolves, `#include <geo/geo.hpp>` compiles and runs, and the example target is absent from the consumer's build.

`version` is kept in sync with `CMakeLists.txt` / `include/geo/version.hpp` by a comment; the existing test suite already asserts those two agree.