### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v1.2.2
+
+Tooling-only release: adds a native Meson build so the library can be
+consumed as a Meson subproject or WrapDB wrap. The library itself is
+unchanged — headers are identical to v1.2.1 apart from the version
+macros, so existing consumers have nothing to update.
+
+### Added
+
+- **Native Meson build** (`meson.build` + `meson_options.txt`): a
+  header-only `declare_dependency` with `meson.override_dependency`, header
+  installation via `install_subdir`, and the self-verifying
+  `examples/gps_track.cpp` wired up as a smoke test — built standalone (or
+  on `-Dtests=enabled`) and skipped when the library is pulled in as a
+  subproject. A `meson-build` CI job runs it so the build can't drift out
+  of sync with the header layout.
+
+### Unchanged (downstream-compatible)
+
+- Every header except the `<geo/version.hpp>` macros is byte-identical to
+  v1.2.1; no API, behavior, or packaging changes.
+
 ## v1.2.1
 
 Tooling-only release: ships the single-header amalgamation as a release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(GeoUtilsCpp VERSION 1.2.1 LANGUAGES CXX)
+project(GeoUtilsCpp VERSION 1.2.2 LANGUAGES CXX)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(_geo_utils_cpp_is_top_level ON)

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ include(FetchContent)
 FetchContent_Declare(
     GeoUtilsCpp
     GIT_REPOSITORY https://github.com/gistrec/geo-utils-cpp.git
-    GIT_TAG        v1.2.1
+    GIT_TAG        v1.2.2
 )
 FetchContent_MakeAvailable(GeoUtilsCpp)
 
@@ -237,7 +237,7 @@ target("your_target")
 ### Conan
 
 ```sh
-conan install --requires=geo-utils-cpp/1.2.1 --build=missing
+conan install --requires=geo-utils-cpp/1.2.2 --build=missing
 ```
 
 Conan Center support is pending
@@ -254,7 +254,7 @@ Conan Center support is pending
 Add the dependency to your package's `manifest`:
 
 ```
-depends: libgeo-utils-cpp ^1.2.1
+depends: libgeo-utils-cpp ^1.2.2
 ```
 
 And in the consuming `buildfile`:
@@ -287,7 +287,7 @@ With any of the above methods (vcpkg, xrepo, Conan, FetchContent, or a
 system `find_package`), wire it into your build with:
 
 ```cmake
-find_package(GeoUtilsCpp 1.2.1 REQUIRED)
+find_package(GeoUtilsCpp 1.2.2 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -698,9 +698,9 @@ the library version for compile-time feature detection:
 
 | Macro | Example | Description |
 |---|---|---|
-| `GEO_UTILS_CPP_VERSION_MAJOR` / `_MINOR` / `_PATCH` | `1` / `2` / `1` | version components |
-| `GEO_UTILS_CPP_VERSION` | `10201` | `major·10000 + minor·100 + patch`, usable in `#if` |
-| `GEO_UTILS_CPP_VERSION_STRING` | `"1.2.1"` | dotted string |
+| `GEO_UTILS_CPP_VERSION_MAJOR` / `_MINOR` / `_PATCH` | `1` / `2` / `2` | version components |
+| `GEO_UTILS_CPP_VERSION` | `10202` | `major·10000 + minor·100 + patch`, usable in `#if` |
+| `GEO_UTILS_CPP_VERSION_STRING` | `"1.2.2"` | dotted string |
 
 ```cpp
 #include <geo/version.hpp>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ include(FetchContent)
 FetchContent_Declare(
     GeoUtilsCpp
     GIT_REPOSITORY https://github.com/gistrec/geo-utils-cpp.git
-    GIT_TAG        v1.2.1
+    GIT_TAG        v1.2.2
 )
 FetchContent_MakeAvailable(GeoUtilsCpp)
 
@@ -64,7 +64,7 @@ for new projects, since the manifest commits alongside your source):
 Either mode, then consume it from CMake:
 
 ```cmake
-find_package(GeoUtilsCpp 1.2.1 REQUIRED)
+find_package(GeoUtilsCpp 1.2.2 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 
@@ -98,7 +98,7 @@ for the xmake variant.
 ### Conan
 
 ```sh
-conan install --requires=geo-utils-cpp/1.2.1 --build=missing
+conan install --requires=geo-utils-cpp/1.2.2 --build=missing
 ```
 
 Conan Center support is pending
@@ -117,7 +117,7 @@ cmake --install build-cmake --prefix /usr/local
 ```
 
 ```cmake
-find_package(GeoUtilsCpp 1.2.1 REQUIRED)
+find_package(GeoUtilsCpp 1.2.2 REQUIRED)
 target_link_libraries(your_target PRIVATE geo::utils)
 ```
 

--- a/include/geo/version.hpp
+++ b/include/geo/version.hpp
@@ -8,7 +8,7 @@
 // consumers get it too; the test suite asserts it matches the CMake version.
 #define GEO_UTILS_CPP_VERSION_MAJOR 1
 #define GEO_UTILS_CPP_VERSION_MINOR 2
-#define GEO_UTILS_CPP_VERSION_PATCH 1
+#define GEO_UTILS_CPP_VERSION_PATCH 2
 
 // Single number for >= comparisons: major * 10000 + minor * 100 + patch,
 // e.g. 1.2.3 -> 10203.
@@ -19,7 +19,7 @@
 #define GEO_UTILS_CPP_VERSION_STR_(x) #x
 #define GEO_UTILS_CPP_VERSION_STR(x) GEO_UTILS_CPP_VERSION_STR_(x)
 
-// "major.minor.patch", e.g. "1.2.1".
+// "major.minor.patch", e.g. "1.2.2".
 #define GEO_UTILS_CPP_VERSION_STRING                  \
     GEO_UTILS_CPP_VERSION_STR(GEO_UTILS_CPP_VERSION_MAJOR) \
     "." GEO_UTILS_CPP_VERSION_STR(GEO_UTILS_CPP_VERSION_MINOR) \

--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: libgeo-utils-cpp
-version: 1.2.1
+version: 1.2.2
 project: geo-utils-cpp
 language: c++
 summary: Header-only C++17 geographic geometry utilities

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@
 project(
   'geo-utils-cpp',
   'cpp',
-  version: '1.2.1',
+  version: '1.2.2',
   license: 'Apache-2.0',
   default_options: ['cpp_std=c++17'],
   meson_version: '>=0.56.0',


### PR DESCRIPTION
Tooling-only release. Tags the native Meson build (merged in #45) so it lands in a source tarball the [WrapDB wrap](https://github.com/mesonbuild/wrapdb/pull/2820) can point at, letting that PR drop its downstream packagefile.

The library itself is unchanged — every header except the `<geo/version.hpp>` macros is byte-identical to v1.2.1. No API, behavior, or packaging changes for existing consumers.

## Version bump

Per `RELEASING.md` step 1: `CMakeLists.txt`, build2 `manifest`, `include/geo/version.hpp`, `meson.build`, `README.md`, `docs/getting-started.md`, `docs/api.md`, and a new `## v1.2.2` section in `CHANGELOG.md`.

## Verified locally

- Full CMake suite: **76/76** (incl. the assertion that `version.hpp` matches `project(VERSION)`).
- Meson: `Project version: 1.2.2`, `gps_track` smoke test passes.

## After merge (not done here)

Tag `v1.2.2` on the green master commit → publish the draft release (with the `geo.hpp` asset) → repoint WrapDB #2820 at the new tag and drop its packagefile. Other registries deliberately stay at 1.2.0.