### PR TITLE
Install only public headers, not build2 metafiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ include(GNUInstallDirs)
 
 install(DIRECTORY include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
 )
 install(TARGETS geo_utils_cpp
     EXPORT GeoUtilsCppTargets

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ meson.override_dependency('geo-utils-cpp', geo_utils_cpp_dep)
 install_subdir(
   'include/geo',
   install_dir: get_option('includedir'),
+  exclude_files: ['buildfile'],
 )
 
 # Build the example only when standalone (or explicitly asked), so downstream


### PR DESCRIPTION
## What

`cmake --install` and `meson install` were leaking the build2 `buildfile` metafiles into the consumer's system include path.

- `CMakeLists.txt` — `install(DIRECTORY include/ ...)` copied the tree wholesale, dropping both `include/buildfile` and `include/geo/buildfile` under `<prefix>/include/`.
- `meson.build` — `install_subdir('include/geo', ...)` did the same for `include/geo/buildfile`.

The build2 build itself never installs these (its `hxx{*}: install = include/geo/` rule only ships headers) — only the CMake and Meson rules did.

## Fix

- CMake: restrict to `FILES_MATCHING PATTERN "*.hpp"`.
- Meson: add `exclude_files: ['buildfile']` to `install_subdir`.

The build2 metafiles stay in the repo untouched — they're required source for the cppget.org package. Header-only change, no version bump, no release.

## Verification

Installed both to a throwaway prefix; each now ships exactly the eight public headers and nothing else:

```
geo/bounds.hpp
geo/detail/math.hpp
geo/encoding.hpp
geo/geo.hpp
geo/latlng.hpp
geo/poly.hpp
geo/spherical.hpp
geo/version.hpp
```

`find <prefix> -name buildfile` → empty for both CMake and Meson. Does not affect the WrapDB consumption path, which pulls headers via the include dir and never runs `meson install`.